### PR TITLE
specifying hb regionserver status command to workaround cdh init script

### DIFF
--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -25,5 +25,7 @@ package "hbase-regionserver" do
 end
 
 service "hbase-regionserver" do
+  # cdh4.4 init scripts do not return non-zero exit codes for status
+  status_command "service hbase-regionserver status | grep -v 'not running'"
   action :nothing
 end


### PR DESCRIPTION
- [x] hbase-regionserver init script for CDH version 4.4 (and presumably others) always returns 0 for status.  adding a grep as workaround
