### PR TITLE
Make sure ZooKeeper's dataLogDir works, even when it isn't set by the user

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,7 +129,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           'hbase.rootdir' => 'hdfs://localhost:8020/hbase',
           'hbase.zookeeper.quorum' => 'localhost',
           'hbase.cluster.distributed' => true
-        },
+        }
+      },
+      :zookeeper => {
+        :zoocfg => {
+          :dataLogDir => '/tmp/zookeeper/logs'
+        }
       }
     }
 

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -44,6 +44,12 @@ if node['zookeeper'].has_key? 'zoocfg'
     else
       "/var/lib/zookeeper"
     end
+  zookeeper_log_dir =
+    if node['zookeeper']['zoocfg'].has_key? 'dataLogDir'
+      node['zookeeper']['zoocfg']['dataLogDir']
+    else
+      "/var/lib/zookeeper"
+    end
   zookeeper_client_port =
     if node['zookeeper']['zoocfg'].has_key? 'clientPort'
       node['zookeeper']['zoocfg']['clientPort']
@@ -52,6 +58,7 @@ if node['zookeeper'].has_key? 'zoocfg'
     end
 
   node.default['zookeeper']['zoocfg']['dataDir'] = zookeeper_data_dir
+  node.default['zookeeper']['zoocfg']['dataLogDir'] = zookeeper_log_dir
   node.default['zookeeper']['zoocfg']['clientPort'] = zookeeper_client_port
   myVars = { :properties => node['zookeeper']['zoocfg'] }
 


### PR DESCRIPTION
This simply extends the dataDir logic to dataLogDir and we put in an attribute in the Vagrantfile to test this.
