### PR TITLE
Feature/services support status

### DIFF
--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -51,6 +51,6 @@ dfs_data_dirs.split(',').each do |dir|
 end
 
 service "hadoop-hdfs-datanode" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -44,6 +44,6 @@ dfs_jn_edits_dirs.split(',').each do |dir|
 end
 
 service "hadoop-hdfs-journalnode" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -72,6 +72,6 @@ execute "hdfs-namenode-format" do
 end
 
 service "hadoop-hdfs-namenode" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -51,6 +51,6 @@ fs_checkpoint_edits_dirs =
 end
 
 service "hadoop-hdfs-secondarynamenode" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hadoop_hdfs_zkfc.rb
+++ b/recipes/hadoop_hdfs_zkfc.rb
@@ -26,6 +26,6 @@ package "hadoop-hdfs-zkfc" do
 end
 
 service "hadoop-hdfs-zkfc" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -47,6 +47,6 @@ end
 end
 
 service "hadoop-yarn-nodemanager" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -30,6 +30,6 @@ end
 # mapreduce.cluster.temp.dir = #{hadoop_tmp_dir}/mapred/temp
 
 service "hadoop-yarn-resourcemanager" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -25,6 +25,6 @@ package "hbase-master" do
 end
 
 service "hbase-master" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -25,7 +25,7 @@ package "hbase-regionserver" do
 end
 
 service "hbase-regionserver" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   # cdh4.4 init scripts do not return non-zero exit codes for status
   status_command "service hbase-regionserver status | grep -v 'not running'"
   action :nothing

--- a/recipes/hbase_thrift.rb
+++ b/recipes/hbase_thrift.rb
@@ -25,6 +25,6 @@ package "hbase-thrift" do
 end
 
 service "hbase-thrift" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -24,6 +24,6 @@ package "hive-metastore" do
 end
 
 service "hive-metastore" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hive_server.rb
+++ b/recipes/hive_server.rb
@@ -24,6 +24,6 @@ package "hive-server" do
 end
 
 service "hive-server" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -26,6 +26,6 @@ package "hive-server2" do
 end
 
 service "hive-server2" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -103,7 +103,7 @@ if node['oozie'].has_key? 'oozie_site'
 end
 
 service "oozie" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end
 

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -104,7 +104,7 @@ if node['hbase'].has_key? 'log4j'
 end # End log4j.properties
 
 service "zookeeper-server" do
-  supports { :restart => true, :reload => false, :status => true }
+  supports [ :restart => true, :reload => false, :status => true ]
   action :nothing
 end
 


### PR DESCRIPTION
When doing some testing, @albertshau noticed an issue where he was unable to send a "stop" to "hadoop-yarn-nodemanager" service and have it stop. Upon further investigation, it was found that the issue was occurring on Ubuntu hosts, but not CentOS hosts, which led to looking into Chef's "service" resource and its "supports" attribute, which has a different value on CentOS and Ubuntu. Since all of the init scripts shipped by Cloudera and Hortonworks support restart and status, we're enabling them, here.
