### PR TITLE
Switch the default version for CDH from 4 to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ zookeeper['zoocfg'] | zoo.cfg | `zookeeper['conf_dir']`
 ## Distribution Attributes
 
 * `hadoop['distribution']` - Specifies which Hadoop distribution to use, currently supported: cdh, hdp. Default `hdp`
-* `hadoop['distribution_version']` - Specifies which version of `hadoop['distribution']` to use. Default `2.0` if `hadoop['distribution']` is `hdp` and `4` if `hadoop['distribution']` is `cdh`
+* `hadoop['distribution_version']` - Specifies which version of `hadoop['distribution']` to use. Default `2.0` if `hadoop['distribution']` is `hdp` and `5` if `hadoop['distribution']` is `cdh`
 
 ### APT-specific settings
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@ default['hadoop']['distribution_version'] =
   if node['hadoop']['distribution'] == 'hdp'
     '2.0'
   elsif node['hadoop']['distribution'] == 'cdh'
-    '4'
+    '5'
   end
 
 # Default: conf.chef


### PR DESCRIPTION
Use CDH5 when a user sets `hadoop['distritbuion']` to `cdh` without setting `hadoop['distribution_version']`
