### PR TITLE
Convert possible strings to boolean before doing checks

### DIFF
--- a/recipes/hadoop_hdfs_ha_checkconfig.rb
+++ b/recipes/hadoop_hdfs_ha_checkconfig.rb
@@ -86,7 +86,7 @@ end # End fencing check
 
 # Start Automatic HA check
 if (node['hadoop']['hdfs_site'].has_key? 'dfs.ha.automatic-failover.enabled' \
-  and node['hadoop']['hdfs_site']['dfs.ha.automatic-failover.enabled'] == true)
+  and node['hadoop']['hdfs_site']['dfs.ha.automatic-failover.enabled'].to_b == true)
   if (node['hadoop']['core_site'].has_key? 'ha.zookeeper.quorum')
     ha_zk_quorum = node['hadoop']['core_site']['ha.zookeeper.quorum'].split(',')
     Chef::Log.info("HA ZooKeeper Quorum: #{ha_zk_quorum}")

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -47,7 +47,7 @@ end
 
 # Are we HA?
 if (node['hadoop'].has_key? 'hdfs_site' and node['hadoop']['hdfs_site'].has_key? 'dfs.ha.automatic-failover.enabled' \
-  and node['hadoop']['hdfs_site']['dfs.ha.automatic-failover.enabled'] == true)
+  and node['hadoop']['hdfs_site']['dfs.ha.automatic-failover.enabled'].to_b == true)
   include_recipe 'hadoop::hadoop_hdfs_ha_checkconfig'
   include_recipe 'hadoop::hadoop_hdfs_zkfc'
 


### PR DESCRIPTION
Otherwise, they may not match if the user sets the attribute to the string 'true'
