### PR TITLE
Fix HiveServer2 on Hortonworks

### DIFF
--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -23,6 +23,17 @@ include_recipe 'hadoop::hive_checkconfig'
 
 package 'hive-server2' do
   action :install
+  # Hortonworks ships this as part of the hive package
+  not_if { node['hadoop']['distribution'] == 'hdp' }
+end
+
+template '/etc/init.d/hive-server2' do
+  source 'hive-server2.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+  action :create
+  only_if { node['hadoop']['distribution'] == 'hdp' }
 end
 
 service 'hive-server2' do

--- a/templates/centos/hive-server2.erb
+++ b/templates/centos/hive-server2.erb
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+# Starts a Hive server
+#
+# chkconfig: 345 90 10
+# description: Starts a Hive server2
+# processname: hive
+# pidfile: /var/run/hive/hive-server2.pid
+### BEGIN INIT INFO
+# Provides:          hive-server2
+# Required-Start:    $syslog $remote_fs
+# Should-Start:
+# Required-Stop:     $syslog $remote_fs
+# Should-Stop:
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Starts a Hive server2
+### END INIT INFO
+
+source /lib/lsb/init-functions
+
+# Autodetect JAVA_HOME if not defined
+if [ -e /usr/libexec/bigtop-detect-javahome ]; then
+  . /usr/libexec/bigtop-detect-javahome
+elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
+  . /usr/lib/bigtop-utils/bigtop-detect-javahome
+fi
+
+RETVAL_SUCCESS=0
+
+STATUS_RUNNING=0
+STATUS_DEAD=1
+STATUS_DEAD_AND_LOCK=2
+STATUS_NOT_RUNNING=3
+
+ERROR_PROGRAM_NOT_INSTALLED=5
+ERROR_PROGRAM_NOT_CONFIGURED=6
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME="hive-server2"
+DESC="Hive server2 daemon"
+SYS_FILE="/etc/default/${NAME}"
+EXE_FILE="/usr/lib/hive/bin/hive"
+PID_FILE="/var/run/hive/${NAME}.pid"
+LOCKFILE="/var/lock/subsys/${NAME}"
+LOG_FILE="/var/log/hive/${NAME}.log"
+HIVE_USER="hive"
+HIVE_HOME="`eval echo ~$HIVE_USER`"
+NICENESS="+0"
+TIMEOUT=3
+
+[ -f $SYS_FILE ] && . $SYS_FILE
+
+hive_start() {
+    [ -x $EXE_FILE ] || exit $ERROR_PROGRAM_NOT_INSTALLED
+
+    service_name="server2"
+    if [ $service_name = "server" ] ; then
+      service_name="hiveserver"
+      exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE`\""
+    fi
+    if [ $service_name = "server2" ] ; then
+      service_name="hiveserver2"
+      exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE`\""
+    fi
+
+    log_success_msg "Starting $desc (${NAME}): "
+    start_daemon -u $HIVE_USER -p $PID_FILE -n $NICENESS  /bin/sh -c "cd $HIVE_HOME ; $exec_env nohup \
+           $EXE_FILE --service $service_name $PORT \
+             > $LOG_FILE 2>&1 < /dev/null & "'echo $! '"> $PID_FILE"
+
+    RETVAL=$?
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && touch $LOCKFILE
+    return $RETVAL
+}
+
+hive_stop() {
+    log_success_msg "Stopping $desc (${NAME}): "
+    killproc -p $PID_FILE java
+    RETVAL=$?
+
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && rm -f $LOCKFILE $PID_FILE
+    return $RETVAL
+}
+
+hive_restart() {
+    hive_stop
+    [ -n "$TIMEOUT" ] && sleep $TIMEOUT
+    hive_start
+}
+
+hive_status() {
+    echo -n "Checking for service $desc: "
+    pidofproc -p $PID_FILE java > /dev/null
+    status=$?
+
+    case "$status" in
+      $STATUS_RUNNING)
+        log_success_msg "server is running"
+        ;;
+      $STATUS_DEAD)
+        log_failure_msg "server is dead and pid file exists"
+        ;;
+      $STATUS_DEAD_AND_LOCK)
+        log_failure_msg "server is dead and lock file exists"
+        ;;
+      $STATUS_NOT_RUNNING)
+        log_failure_msg "server is not running"
+        ;;
+      *)
+        log_failure_msg "server status is unknown"
+        ;;
+    esac
+    return $status
+}
+
+RETVAL=0
+
+case "$1" in
+    start)
+      hive_start
+      ;;
+
+    stop|force-stop)
+      hive_stop
+      ;; 
+
+    force-reload|condrestart|try-restart)
+      [ -e $LOCKFILE ] && hive_restart || :
+      ;;
+
+    restart|reload)
+      hive_restart
+      ;;
+  
+    status)
+      hive_status
+      ;;
+
+    *)
+	N=/etc/init.d/$NAME
+	echo "Usage: $N {start|stop|restart|reload|condrestart|try-restart|force-reload|status|force-stop}" >&2
+
+	exit 1
+	;;
+esac
+
+exit $RETVAL

--- a/templates/default/hive-server2.erb
+++ b/templates/default/hive-server2.erb
@@ -1,0 +1,169 @@
+#! /bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# skeleton  example file to build /etc/init.d/ scripts.
+#    This file should be used to construct scripts for /etc/init.d.
+#
+#    Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+#    Modified for Debian
+#    by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+#               Further changes by Javier Fernandez-Sanguino <jfs@debian.org>
+#
+# Starts a Hive server2
+#
+# chkconfig: 345 85 15
+# description: Starts a Hive server2
+# processname: hive
+#
+### BEGIN INIT INFO
+# Provides:          hive-server2
+# Required-Start:    $syslog $remote_fs
+# Should-Start:
+# Required-Stop:     $syslog $remote_fs
+# Should-Stop:
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Starts a Hive server2
+### END INIT INFO
+
+source /lib/lsb/init-functions
+
+# Autodetect JAVA_HOME if not defined
+if [ -e /usr/libexec/bigtop-detect-javahome ]; then
+  . /usr/libexec/bigtop-detect-javahome
+elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
+  . /usr/lib/bigtop-utils/bigtop-detect-javahome
+fi
+
+RETVAL_SUCCESS=0
+
+STATUS_RUNNING=0
+STATUS_DEAD=1
+STATUS_DEAD_AND_LOCK=2
+STATUS_NOT_RUNNING=3
+STATUS_DEBIAN_NOT_RUNNING=4
+
+ERROR_PROGRAM_NOT_INSTALLED=5
+ERROR_PROGRAM_NOT_CONFIGURED=6
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME="hive-server2"
+DESC="Hive server2 daemon"
+SYS_FILE="/etc/default/${NAME}"
+EXE_FILE="/usr/lib/hive/bin/hive"
+PID_FILE="/var/run/hive/${NAME}.pid"
+LOCKFILE="/var/lock/subsys/${NAME}"
+LOG_FILE="/var/log/hive/${NAME}.log"
+HIVE_USER="hive"
+HIVE_HOME="`eval echo ~$HIVE_USER`"
+NICENESS="+0"
+TIMEOUT=3
+
+[ -f $SYS_FILE ] && . $SYS_FILE
+
+hive_start() {
+    [ -x $EXE_FILE ] || exit $ERROR_PROGRAM_NOT_INSTALLED
+
+    exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE` -Dhive.log.file=${NAME}.log -Dhive.log.threshold=INFO\""
+    service_name="server"
+    if [ $service_name = "server" ] ; then
+      service_name="hiveserver2"
+    fi
+
+    log_success_msg "Starting $desc (${NAME}): "
+    /sbin/start-stop-daemon --quiet --oknodo --start --user $HIVE_USER --name java --background \
+       --chuid $HIVE_USER --nicelevel $NICENESS --chdir $HIVE_HOME \
+       --make-pidfile --pidfile $PID_FILE --startas /bin/sh -- \
+       -c "$exec_env exec $EXE_FILE --service $service_name $PORT > $LOG_FILE 2>&1 < /dev/null"
+
+    RETVAL=$?
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && touch $LOCKFILE
+    return $RETVAL
+}
+
+hive_stop() {
+    log_success_msg "Stopping $desc (${NAME}): "
+    killproc -p $PID_FILE java
+    RETVAL=$?
+
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && rm -f $LOCKFILE $PID_FILE
+    return $RETVAL
+}
+
+hive_restart() {
+    hive_stop
+    [ -n "$TIMEOUT" ] && sleep $TIMEOUT
+    hive_start
+}
+
+hive_status() {
+    echo -n "Checking for service $desc: "
+    pidofproc -p $PID_FILE java > /dev/null
+    RETVAL=$?
+
+    case "$RETVAL" in
+      $STATUS_RUNNING)
+        log_success_msg "server is running"
+        ;;
+      $STATUS_DEAD)
+        log_failure_msg "server is dead and pid file exists"
+        ;;
+      $STATUS_DEAD_AND_LOCK)
+        log_failure_msg "server is dead and lock file exists"
+        ;;
+      $STATUS_NOT_RUNNING|$STATUS_DEBIAN_NOT_RUNNING)
+        log_failure_msg "server is not running"
+        ;;
+      *)
+        log_failure_msg "server status is unknown"
+        ;;
+    esac
+    return $RETVAL
+}
+
+RETVAL=0
+
+case "$1" in
+    start)
+      hive_start
+      ;;
+
+    stop|force-stop)
+      hive_stop
+      ;; 
+
+    force-reload|condrestart|try-restart)
+      [ -e $LOCKFILE ] && hive_restart || :
+      ;;
+
+    restart|reload)
+      hive_restart
+      ;;
+  
+    status)
+      hive_status
+      ;;
+
+    *)
+	N=/etc/init.d/$NAME
+	echo "Usage: $N {start|stop|restart|reload|condrestart|try-restart|force-reload|status|force-stop}" >&2
+
+	exit 1
+	;;
+esac
+
+exit $RETVAL

--- a/templates/redhat/hive-server2.erb
+++ b/templates/redhat/hive-server2.erb
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+# Starts a Hive server
+#
+# chkconfig: 345 90 10
+# description: Starts a Hive server2
+# processname: hive
+# pidfile: /var/run/hive/hive-server2.pid
+### BEGIN INIT INFO
+# Provides:          hive-server2
+# Required-Start:    $syslog $remote_fs
+# Should-Start:
+# Required-Stop:     $syslog $remote_fs
+# Should-Stop:
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Starts a Hive server2
+### END INIT INFO
+
+source /lib/lsb/init-functions
+
+# Autodetect JAVA_HOME if not defined
+if [ -e /usr/libexec/bigtop-detect-javahome ]; then
+  . /usr/libexec/bigtop-detect-javahome
+elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
+  . /usr/lib/bigtop-utils/bigtop-detect-javahome
+fi
+
+RETVAL_SUCCESS=0
+
+STATUS_RUNNING=0
+STATUS_DEAD=1
+STATUS_DEAD_AND_LOCK=2
+STATUS_NOT_RUNNING=3
+
+ERROR_PROGRAM_NOT_INSTALLED=5
+ERROR_PROGRAM_NOT_CONFIGURED=6
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME="hive-server2"
+DESC="Hive server2 daemon"
+SYS_FILE="/etc/default/${NAME}"
+EXE_FILE="/usr/lib/hive/bin/hive"
+PID_FILE="/var/run/hive/${NAME}.pid"
+LOCKFILE="/var/lock/subsys/${NAME}"
+LOG_FILE="/var/log/hive/${NAME}.log"
+HIVE_USER="hive"
+HIVE_HOME="`eval echo ~$HIVE_USER`"
+NICENESS="+0"
+TIMEOUT=3
+
+[ -f $SYS_FILE ] && . $SYS_FILE
+
+hive_start() {
+    [ -x $EXE_FILE ] || exit $ERROR_PROGRAM_NOT_INSTALLED
+
+    service_name="server2"
+    if [ $service_name = "server" ] ; then
+      service_name="hiveserver"
+      exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE`\""
+    fi
+    if [ $service_name = "server2" ] ; then
+      service_name="hiveserver2"
+      exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE`\""
+    fi
+
+    log_success_msg "Starting $desc (${NAME}): "
+    start_daemon -u $HIVE_USER -p $PID_FILE -n $NICENESS  /bin/sh -c "cd $HIVE_HOME ; $exec_env nohup \
+           $EXE_FILE --service $service_name $PORT \
+             > $LOG_FILE 2>&1 < /dev/null & "'echo $! '"> $PID_FILE"
+
+    RETVAL=$?
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && touch $LOCKFILE
+    return $RETVAL
+}
+
+hive_stop() {
+    log_success_msg "Stopping $desc (${NAME}): "
+    killproc -p $PID_FILE java
+    RETVAL=$?
+
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && rm -f $LOCKFILE $PID_FILE
+    return $RETVAL
+}
+
+hive_restart() {
+    hive_stop
+    [ -n "$TIMEOUT" ] && sleep $TIMEOUT
+    hive_start
+}
+
+hive_status() {
+    echo -n "Checking for service $desc: "
+    pidofproc -p $PID_FILE java > /dev/null
+    status=$?
+
+    case "$status" in
+      $STATUS_RUNNING)
+        log_success_msg "server is running"
+        ;;
+      $STATUS_DEAD)
+        log_failure_msg "server is dead and pid file exists"
+        ;;
+      $STATUS_DEAD_AND_LOCK)
+        log_failure_msg "server is dead and lock file exists"
+        ;;
+      $STATUS_NOT_RUNNING)
+        log_failure_msg "server is not running"
+        ;;
+      *)
+        log_failure_msg "server status is unknown"
+        ;;
+    esac
+    return $status
+}
+
+RETVAL=0
+
+case "$1" in
+    start)
+      hive_start
+      ;;
+
+    stop|force-stop)
+      hive_stop
+      ;; 
+
+    force-reload|condrestart|try-restart)
+      [ -e $LOCKFILE ] && hive_restart || :
+      ;;
+
+    restart|reload)
+      hive_restart
+      ;;
+  
+    status)
+      hive_status
+      ;;
+
+    *)
+	N=/etc/init.d/$NAME
+	echo "Usage: $N {start|stop|restart|reload|condrestart|try-restart|force-reload|status|force-stop}" >&2
+
+	exit 1
+	;;
+esac
+
+exit $RETVAL

--- a/templates/scientific/hive-server2.erb
+++ b/templates/scientific/hive-server2.erb
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+# Starts a Hive server
+#
+# chkconfig: 345 90 10
+# description: Starts a Hive server2
+# processname: hive
+# pidfile: /var/run/hive/hive-server2.pid
+### BEGIN INIT INFO
+# Provides:          hive-server2
+# Required-Start:    $syslog $remote_fs
+# Should-Start:
+# Required-Stop:     $syslog $remote_fs
+# Should-Stop:
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Starts a Hive server2
+### END INIT INFO
+
+source /lib/lsb/init-functions
+
+# Autodetect JAVA_HOME if not defined
+if [ -e /usr/libexec/bigtop-detect-javahome ]; then
+  . /usr/libexec/bigtop-detect-javahome
+elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
+  . /usr/lib/bigtop-utils/bigtop-detect-javahome
+fi
+
+RETVAL_SUCCESS=0
+
+STATUS_RUNNING=0
+STATUS_DEAD=1
+STATUS_DEAD_AND_LOCK=2
+STATUS_NOT_RUNNING=3
+
+ERROR_PROGRAM_NOT_INSTALLED=5
+ERROR_PROGRAM_NOT_CONFIGURED=6
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME="hive-server2"
+DESC="Hive server2 daemon"
+SYS_FILE="/etc/default/${NAME}"
+EXE_FILE="/usr/lib/hive/bin/hive"
+PID_FILE="/var/run/hive/${NAME}.pid"
+LOCKFILE="/var/lock/subsys/${NAME}"
+LOG_FILE="/var/log/hive/${NAME}.log"
+HIVE_USER="hive"
+HIVE_HOME="`eval echo ~$HIVE_USER`"
+NICENESS="+0"
+TIMEOUT=3
+
+[ -f $SYS_FILE ] && . $SYS_FILE
+
+hive_start() {
+    [ -x $EXE_FILE ] || exit $ERROR_PROGRAM_NOT_INSTALLED
+
+    service_name="server2"
+    if [ $service_name = "server" ] ; then
+      service_name="hiveserver"
+      exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE`\""
+    fi
+    if [ $service_name = "server2" ] ; then
+      service_name="hiveserver2"
+      exec_env="HADOOP_OPTS=\"-Dhive.log.dir=`dirname $LOG_FILE`\""
+    fi
+
+    log_success_msg "Starting $desc (${NAME}): "
+    start_daemon -u $HIVE_USER -p $PID_FILE -n $NICENESS  /bin/sh -c "cd $HIVE_HOME ; $exec_env nohup \
+           $EXE_FILE --service $service_name $PORT \
+             > $LOG_FILE 2>&1 < /dev/null & "'echo $! '"> $PID_FILE"
+
+    RETVAL=$?
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && touch $LOCKFILE
+    return $RETVAL
+}
+
+hive_stop() {
+    log_success_msg "Stopping $desc (${NAME}): "
+    killproc -p $PID_FILE java
+    RETVAL=$?
+
+    [ $RETVAL -eq $RETVAL_SUCCESS ] && rm -f $LOCKFILE $PID_FILE
+    return $RETVAL
+}
+
+hive_restart() {
+    hive_stop
+    [ -n "$TIMEOUT" ] && sleep $TIMEOUT
+    hive_start
+}
+
+hive_status() {
+    echo -n "Checking for service $desc: "
+    pidofproc -p $PID_FILE java > /dev/null
+    status=$?
+
+    case "$status" in
+      $STATUS_RUNNING)
+        log_success_msg "server is running"
+        ;;
+      $STATUS_DEAD)
+        log_failure_msg "server is dead and pid file exists"
+        ;;
+      $STATUS_DEAD_AND_LOCK)
+        log_failure_msg "server is dead and lock file exists"
+        ;;
+      $STATUS_NOT_RUNNING)
+        log_failure_msg "server is not running"
+        ;;
+      *)
+        log_failure_msg "server status is unknown"
+        ;;
+    esac
+    return $status
+}
+
+RETVAL=0
+
+case "$1" in
+    start)
+      hive_start
+      ;;
+
+    stop|force-stop)
+      hive_stop
+      ;; 
+
+    force-reload|condrestart|try-restart)
+      [ -e $LOCKFILE ] && hive_restart || :
+      ;;
+
+    restart|reload)
+      hive_restart
+      ;;
+  
+    status)
+      hive_status
+      ;;
+
+    *)
+	N=/etc/init.d/$NAME
+	echo "Usage: $N {start|stop|restart|reload|condrestart|try-restart|force-reload|status|force-stop}" >&2
+
+	exit 1
+	;;
+esac
+
+exit $RETVAL


### PR DESCRIPTION
This fixes HiveServer2 on Hortonworks HDP 2.0, since it is pretty much unusable.
- [x] Do not install `hive-server2` package, since it doesn't exist (binaries come with hive package)
- [x] Copied `hive-server` init script for RHEL into centos/redhat/scientific template directories
- [x] Copied `hive-server` init script for Ubuntu into default

This has been tested in vagrant in CentOS 6.4 and Ubuntu 12.04 and the service starts and runs on both.
