### PR TITLE
Add "support" for Ubuntu 13.04 (raring lsb codename)

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -126,7 +126,7 @@ when 'cdh'
   when 'debian'
     codename = node['lsb']['codename']
     
-    if codename = 'raring'
+    if codename == 'raring'
     	codename = 'precise'
     end
     


### PR DESCRIPTION
Cloudera only recognizes Precise (12.04) and Lucid. This pull request points to the Precise repo on Raring (13.04) systems. 

This _seem_ to work by pointing 13.04 systems to the 12.04 packages - haven't fully tested but things seem copacetic in initial smoke tests. 
