### PR TITLE
Feature/hdfs tmpdir

### DIFF
--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -73,6 +73,16 @@ execute 'hdfs-namenode-format' do
   user 'hdfs'
 end
 
+# We need a /tmp in HDFS
+dfs = node['hadoop']['core_site']['fs.defaultFS']
+execute 'hdfs-tmpdir' do
+  command "hdfs dfs -mkdir -p #{dfs}/tmp && hdfs dfs -chmod 1777 #{dfs}/tmp"
+  timeout 300
+  user 'hdfs'
+  group 'hdfs'
+  action :nothing
+end
+
 service 'hadoop-hdfs-namenode' do
   supports [:restart => true, :reload => false, :status => true]
   action :nothing

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -29,17 +29,6 @@ end
 # mapreduce.jobtracker.staging.root.dir = #{hadoop_tmp_dir}/mapred/staging
 # mapreduce.cluster.temp.dir = #{hadoop_tmp_dir}/mapred/temp
 
-# YARN needs a /tmp in HDFS
-dfs = node['hadoop']['core_site']['fs.defaultFS']
-execute 'yarn-hdfs-tmpdir' do
-  command "hdfs dfs -mkdir -p #{dfs}/tmp && hdfs dfs -chmod 1777 #{dfs}/tmp"
-  timeout 300
-  user 'hdfs'
-  group 'hdfs'
-  not_if "hdfs dfs -test -d #{dfs}/tmp", :user => 'hdfs'
-  action :nothing
-end
-
 service 'hadoop-yarn-resourcemanager' do
   supports [:restart => true, :reload => false, :status => true]
   action :nothing


### PR DESCRIPTION
Remove yarn-hdfs-tmpdir and create hdfs-tmpdir in hadoop_hdfs_namenode, since this is a global HDFS directory
