### PR TITLE
Feature/hive warehouse perms

### DIFF
--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -54,7 +54,7 @@ unless scratch_dir == '/tmp/hive-${user.name}'
 end
 
 execute 'hive-hdfs-warehousedir' do
-  command "hdfs dfs -mkdir -p #{dfs}/#{warehouse_dir} && hdfs dfs -chown hive:hdfs #{dfs}/#{warehouse_dir}"
+  command "hdfs dfs -mkdir -p #{dfs}/#{warehouse_dir} && hdfs dfs -chown hive:hdfs #{dfs}/#{warehouse_dir} && hdfs dfs -chmod 1777 #{dfs}/#{warehouse_dir}"
   timeout 300
   user 'hdfs'
   group 'hdfs'


### PR DESCRIPTION
The Hive warehouse directory should be set to 1777, per http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.3.0/CDH4-Installation-Guide/cdh4ig_topic_18_7.html
