### PR TITLE
Feature/move hdfs-tmpdir to resourcemanager

### DIFF
--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -73,16 +73,6 @@ execute 'hdfs-namenode-format' do
   user 'hdfs'
 end
 
-# We need a /tmp in HDFS
-dfs = node['hadoop']['core_site']['fs.defaultFS']
-execute 'hdfs-tmpdir' do
-  command "hdfs dfs -mkdir -p #{dfs}/tmp && hdfs dfs -chmod 1777 #{dfs}/tmp"
-  timeout 300
-  user 'hdfs'
-  group 'hdfs'
-  action :nothing
-end
-
 service 'hadoop-hdfs-namenode' do
   supports [:restart => true, :reload => false, :status => true]
   action :nothing

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -29,6 +29,16 @@ end
 # mapreduce.jobtracker.staging.root.dir = #{hadoop_tmp_dir}/mapred/staging
 # mapreduce.cluster.temp.dir = #{hadoop_tmp_dir}/mapred/temp
 
+# We need a /tmp in HDFS
+dfs = node['hadoop']['core_site']['fs.defaultFS']
+execute 'hdfs-tmpdir' do
+  command "hdfs dfs -mkdir -p #{dfs}/tmp && hdfs dfs -chmod 1777 #{dfs}/tmp"
+  timeout 300
+  user 'hdfs'
+  group 'hdfs'
+  action :nothing
+end
+
 service 'hadoop-yarn-resourcemanager' do
   supports [:restart => true, :reload => false, :status => true]
   action :nothing

--- a/spec/hadoop_hdfs_namenode_spec.rb
+++ b/spec/hadoop_hdfs_namenode_spec.rb
@@ -24,10 +24,6 @@ describe 'hadoop::hadoop_hdfs_namenode' do
       expect(chef_run).to_not run_execute('hdfs-namenode-format').with(user: 'hdfs')
     end
 
-    it 'creates hdfs-tmpdir execute resource, but does not run it' do
-      expect(chef_run).to_not run_execute('hdfs-tmpdir').with(user: 'hdfs')
-    end
-
     it 'creates hadoop-hdfs-namenode service resource, but does not run it' do
       expect(chef_run).to_not disable_service('hadoop-hdfs-namenode')
       expect(chef_run).to_not enable_service('hadoop-hdfs-namenode')

--- a/spec/hadoop_yarn_resourcemanager_spec.rb
+++ b/spec/hadoop_yarn_resourcemanager_spec.rb
@@ -13,8 +13,8 @@ describe 'hadoop::hadoop_yarn_resourcemanager' do
       expect(chef_run).to install_package('hadoop-yarn-resourcemanager')
     end
 
-    it 'creates yarn-hdfs-tmpdir execute resource, but does not run it' do
-      expect(chef_run).to_not run_execute('yarn-hdfs-tmpdir').with(user: 'hdfs')
+    it 'creates hdfs-tmpdir execute resource, but does not run it' do
+      expect(chef_run).to_not run_execute('hdfs-tmpdir').with(user: 'hdfs')
     end
 
     it 'creates hadoop-yarn-resourcemanager service resource, but does not run it' do


### PR DESCRIPTION
Wrapping the hdfs-tmpdir execute resource was problematic, so moving it back to YARN ResourceManager
