### PR TITLE
Feature/issue 59

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -186,7 +186,7 @@ if node['hadoop']['core_site']['hadoop.tmp.dir'] == 'file:///tmp/hadoop-${user}'
   end
 elsif node['hadoop']['core_site']['hadoop.tmp.dir'] =~ /${user}/
   # Since we're creating a 1777 directory, Hadoop can create the user-specific subdirectories, itself
-  directory File.dirname(hadoop_tmp_dir.gsub('file://', '') do
+  directory File.dirname(hadoop_tmp_dir.gsub('file://', '')) do
     mode '1777'
     action :create
     recursive true


### PR DESCRIPTION
Add another code path to match paths with `${user}` in them. This strips the final directory off the path, and creates the parent with `mode 1777`, which should be sufficient for supporting paths ending in `hadoop-${user}` as requested in issue #59 ...

This is **not** perfect, but it resolves this use case. A better solution would be to traverse the path and find the element that has `${user}` in it and simply create the parent as `mode 1777` and let Hadoop create subsequent directories.
