### PR TITLE
Feature/fix hdp ubuntu repo

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -90,7 +90,6 @@ when 'hdp'
     end
 
   when 'debian'
-    Chef::Log.warn('HDP only supports version 2.0 on Ubuntu at this time') unless node['hadoop']['distribution_version'] == '2.0'
     apt_base_url = 'http://public-repo-1.hortonworks.com/HDP'
     os = "ubuntu#{major_platform_version}"
     hdp_update_version = hdp_version if hdp_update_version.nil?


### PR DESCRIPTION
This fixes installing HDP 2.0 on Ubuntu and adds support for HDP 2.1.3.0 update.
