### PR TITLE
Feature/more repo fixes

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -53,7 +53,13 @@ when 'hdp'
   case node['platform_family']
   when 'rhel'
     yum_base_url = 'http://public-repo-1.hortonworks.com/HDP'
-    os = "centos#{major_platform_version}"
+    # HDP supports 5 and 6
+    case major_platform_version
+    when 5, 6
+      os = "centos#{major_platform_version}"
+    else
+      Chef::Application.fatal!('HDP only supports RHEL/CentOS 5 and 6!')
+    end
     yum_repo_url = node['hadoop']['yum_repo_url'] ? node['hadoop']['yum_repo_url'] : "#{yum_base_url}/#{os}/2.x/GA/#{hdp_version}"
     yum_repo_key_url = node['hadoop']['yum_repo_key_url'] ? node['hadoop']['yum_repo_key_url'] : "#{yum_base_url}/#{os}/#{key}/#{key}-Jenkins"
 
@@ -91,7 +97,13 @@ when 'hdp'
 
   when 'debian'
     apt_base_url = 'http://public-repo-1.hortonworks.com/HDP'
-    os = "ubuntu#{major_platform_version}"
+    # HDP only supports Debian 6 and Ubuntu 12
+    case node['platform']
+    when 'debian'
+      os = "#{node['platform']}6"
+    else
+      os = "#{node['platform']}12"
+    end
     hdp_update_version = hdp_version if hdp_update_version.nil?
     apt_repo_url = node['hadoop']['apt_repo_url'] ? node['hadoop']['apt_repo_url'] : "#{apt_base_url}/#{os}/#{hdp_update_version}"
     # Hortonworks don't know how to provide a key, but we do


### PR DESCRIPTION
Further restrict possible URLs for HDP repositories to only supported distributions (centos5/6, debian6, ubuntu12)

This should resolve issues using HDP on Ubuntu 13 or 14
