### PR TITLE
Feature/zookeeper security

### DIFF
--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -129,6 +129,20 @@ if node['zookeeper'].key? 'zookeeper_env'
   end
 end # End zookeeper-env.sh
 
+# Setup jaas.conf
+if node['zookeeper'].key?('jaas')
+  my_vars = { :options => node['zookeeper']['jaas'] }
+
+  template "#{zookeeper_conf_dir}/jaas.conf" do
+    source 'jaas.conf.erb'
+    mode '0755'
+    owner 'zookeeper'
+    group 'zookeeper'
+    action :create
+    variables my_vars
+  end
+end # End jaas.conf
+
 # Setup log4j.properties
 if node['zookeeper'].key? 'log4j'
   my_vars = { :properties => node['zookeeper']['log4j'] }

--- a/templates/default/jaas.conf.erb
+++ b/templates/default/jaas.conf.erb
@@ -1,0 +1,8 @@
+Server {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=<%= useKeyTab %>
+  keyTab="<%= keyTab %>
+  storeKey=true
+  useTicketCache=false
+  principal="<%= principal %>";
+};


### PR DESCRIPTION
ZooKeeper uses JAAS for security. This creates the `jaas.conf` in the `zookeeper['conf_dir']` and adds missing support for `zookeeper-env.sh`
