### PR TITLE
Create zookeeper group after installing packages

### DIFF
--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -24,6 +24,11 @@ package 'zookeeper-server' do
   action :install
 end
 
+# HDP 2.0.11.0 (maybe others) doesn't create zookeeper group
+group 'zookeeper' do
+  action :create
+end
+
 zookeeper_conf_dir = "/etc/zookeeper/#{node['zookeeper']['conf_dir']}"
 
 # Setup zoo.cfg


### PR DESCRIPTION
Otherwise, running `service zookeeper-server init` will fail, since it tries to create a directory as user/group `zookeeper` even though the Hortonworks packages do not create that group.
