### PR TITLE
Simplify HDP repository handling for platform_family == rhel

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -63,28 +63,11 @@ when 'hdp'
   case node['platform_family']
   when 'rhel'
     yum_base_url = 'http://public-repo-1.hortonworks.com/HDP'
-    case node['platform']
-    # Only do a fatal version check on redhat/centos
-    # rubocop: disable BlockNesting
-    when 'redhat', 'centos'
-      # HDP supports 5 and 6
-      case major_platform_version
-      when 5, 6
-        os = "centos#{major_platform_version}"
-      else
-        Chef::Application.fatal!('HDP only supports RHEL/CentOS 5 and 6!')
-      end
-    # Force amazon linux to use centos6 packages
-    when 'amazon'
-      case major_platform_version
-      when 2014
-        os = 'centos6'
-        Chef::Log.warn('You are running on an unsupported platform! Forcing OS version to CentOS 6 for Hadoop!')
-      else
-        Chef::Application.fatal!('Your version of Amazon Linux has not been tested. File a bug report, if it works for you.')
-      end
+    if major_platform_version == 5
+      os = "centos#{major_platform_version}"
+    else
+      os = 'centos6'
     end
-    # rubocop: enable BlockNesting
 
     yum_repo_url = node['hadoop']['yum_repo_url'] ? node['hadoop']['yum_repo_url'] : "#{yum_base_url}/#{os}/2.x/GA/#{hdp_version}"
     yum_repo_key_url = node['hadoop']['yum_repo_key_url'] ? node['hadoop']['yum_repo_key_url'] : "#{yum_base_url}/#{os}/#{key}/#{key}-Jenkins"


### PR DESCRIPTION
Rather than be stringent on which versions we support, detect usage of RHEL 5 equivalents. Otherwise, use the "centos6" repository, which should support centos, redhat, and scientific versions. Amazon will be treated as RHEL 6 equivalent.
