### PR TITLE
updating default bigtop version to 0.8.0

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -35,7 +35,7 @@ node.default['hadoop']['distribution_version'] =
   elsif node['hadoop']['distribution'] == 'cdh'
     '5'
   elsif node['hadoop']['distribution'] == 'bigtop'
-    '0.7.0'
+    '0.8.0'
   end
 
 case node['hadoop']['distribution']


### PR DESCRIPTION
updating default bigtop version.  verified in vagrant.

```
hadoop-hdfs-2.4.1.6-1.el6.x86_64
hadoop-hdfs-secondarynamenode-2.4.1.6-1.el6.x86_64
hadoop-2.4.1.6-1.el6.x86_64
hadoop-client-2.4.1.6-1.el6.x86_64
hadoop-yarn-resourcemanager-2.4.1.6-1.el6.x86_64
hadoop-yarn-2.4.1.6-1.el6.x86_64
hadoop-hdfs-namenode-2.4.1.6-1.el6.x86_64
hadoop-yarn-nodemanager-2.4.1.6-1.el6.x86_64
hadoop-mapreduce-2.4.1.6-1.el6.x86_64
hadoop-hdfs-datanode-2.4.1.6-1.el6.x86_64
```
