### PR TITLE
Remove unused gems, update berkshelf/chefspec/rspec and unconstrain rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 2.0'
+gem 'berkshelf', '~> 3.0'
 gem 'foodcritic', '~> 3.0'
-gem 'thor-foodcritic'
 
-group :development do
-  gem 'guard'
-  gem 'guard-kitchen'
-  gem 'guard-foodcritic'
-end
+gem 'chefspec', '~> 4.0'
+gem 'rspec', '~> 3.0'
 
-gem 'chefspec', '~> 3.1'
-gem 'rspec', '~> 2.14.1'
-
-gem 'rubocop', '~> 0.21.0'
+gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'
 


### PR DESCRIPTION
Before:

```
ChefSpec Coverage report generated...

  Total Resources:   119
  Touched Resources: 109
  Touch Coverage:    91.6%

Untouched Resources:

  link[/usr/lib/hive/lib/mysql-connector-java.jar]   hadoop/recipes/hive.rb:61
  link[/usr/lib/hive/lib/postgresql-jdbc.jar]   hadoop/recipes/hive.rb:61
  directory[/tmp/${user.name}]       hadoop/recipes/hive.rb:88
  template[/etc/hive/conf.chef/hive-site.xml]   hadoop/recipes/hive.rb:100
  execute[hive-hdfs-warehousedir]    hadoop/recipes/hive_metastore.rb:56
  directory[/tmp]                    hadoop/recipes/hive.rb:88
  link[/usr/lib/hive/lib/postgresql-jdbc4.jar]   hadoop/recipes/hive.rb:61
  log[hdp-2.1 release engineering fix]   hadoop/recipes/zookeeper_server.rb:143
  directory[/usr/lib/bigtop-utils]   hadoop/recipes/zookeeper_server.rb:147
  file[/usr/lib/bigtop-utils/bigtop-detect-javahome]   hadoop/recipes/zookeeper_server.rb:150
```

After:

```
ChefSpec Coverage report generated...

  Total Resources:   119
  Touched Resources: 112
  Touch Coverage:    94.12%

Untouched Resources:

  directory[/tmp/${user.name}]       hadoop/recipes/hive.rb:88
  template[/etc/hive/conf.chef/hive-site.xml]   hadoop/recipes/hive.rb:100
  execute[hive-hdfs-warehousedir]    hadoop/recipes/hive_metastore.rb:56
  directory[/tmp]                    hadoop/recipes/hive.rb:88
  log[hdp-2.1 release engineering fix]   hadoop/recipes/zookeeper_server.rb:143
  directory[/usr/lib/bigtop-utils]   hadoop/recipes/zookeeper_server.rb:147
  file[/usr/lib/bigtop-utils/bigtop-detect-javahome]   hadoop/recipes/zookeeper_server.rb:150
```
