### PR TITLE
Only test default in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,18 +86,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     chef.run_list = [
       'recipe[minitest-handler::default]',
       'recipe[java::default]',
-      'recipe[hadoop::default]',
-      'recipe[hadoop::hadoop_hdfs_namenode]',
-      'recipe[hadoop::hadoop_hdfs_datanode]',
-      'recipe[hadoop::hadoop_hdfs_secondarynamenode]',
-      'recipe[hadoop::hadoop_yarn_resourcemanager]',
-      'recipe[hadoop::hadoop_yarn_nodemanager]',
-      'recipe[hadoop::zookeeper_server]',
-      'recipe[hadoop::hbase_master]',
-      'recipe[hadoop::hbase_regionserver]',
-      'recipe[hadoop::hive_server2]',
-      'recipe[hadoop::hive_metastore]',
-      'recipe[hadoop::oozie]'
+      'recipe[hadoop::default]'
     ]
   end
 end


### PR DESCRIPTION
There's no need to run through a large number of recipes. Users can add their own recipes if they want to test specific features.
