### PR TITLE
COOK-6 Initial Avro support

### DIFF
--- a/recipes/avro.rb
+++ b/recipes/avro.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: hadoop
+# Recipe:: avro
+#
+# Copyright © 2013-2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'hadoop::repo'
+
+package 'avro-tools' do
+  action :install
+  only_if { node['hadoop']['distribution'] == 'cdh' }
+end

--- a/spec/avro_spec.rb
+++ b/spec/avro_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'hadoop::avro' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+      end.converge(described_recipe)
+    end
+
+    it 'does not install avro-tools package' do
+      expect(chef_run).not_to install_package('avro-tools')
+    end
+  end
+
+  context 'using CDH 5' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.override['hadoop']['distribution'] = 'cdh'
+        node.override['hadoop']['distribution_version'] = 5
+        node.automatic['domain'] = 'example.com'
+      end.converge(described_recipe)
+    end
+
+    it 'installs avro-tools package' do
+      expect(chef_run).to install_package('avro-tools')
+    end
+  end
+end


### PR DESCRIPTION
This installs the `avro-tools` package, which installs all of the Avro JARs (via `avro-libs` package) and the `avro-tools` binary.
