### PR TITLE
Proper matching for *_LOG_DIR variables in env files

### DIFF
--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -81,7 +81,7 @@ if node['hbase'].key?('hbase_env')
     only_if { node['hbase']['hbase_env'].key?('hbase_log_dir') }
   end
 
-  unless node['hbase']['hbase_env']['hbase_log_dir'] == '/var/log/hbase'
+  unless hbase_log_dir == '/var/log/hbase'
     # Delete default directory, if we aren't set to it
     directory '/var/log/hbase' do
       action :delete
@@ -89,7 +89,7 @@ if node['hbase'].key?('hbase_env')
     end
     # symlink
     link '/var/log/hbase' do
-      to node['hbase']['hbase_env']['hbase_log_dir']
+      to hbase_log_dir
     end
   end
 

--- a/recipes/hive.rb
+++ b/recipes/hive.rb
@@ -125,7 +125,7 @@ if node['hive'].key?('hive_env')
     only_if { node['hive']['hive_env'].key?('hive_log_dir') }
   end
 
-  unless node['hive']['hive_env']['hive_log_dir'] == '/var/log/hive'
+  unless hive_log_dir == '/var/log/hive'
     # Delete default directory, if we aren't set to it
     directory '/var/log/hive' do
       action :delete
@@ -133,7 +133,7 @@ if node['hive'].key?('hive_env')
     end
     # symlink
     link '/var/log/hive' do
-      to node['hive']['hive_env']['hive_log_dir']
+      to hive_log_dir
     end
   end
 

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -122,7 +122,7 @@ if node['oozie'].key?('oozie_env')
     only_if { node['oozie']['oozie_env'].key?('oozie_log_dir') }
   end
 
-  unless node['oozie']['oozie_env']['oozie_log_dir'] == '/var/log/oozie'
+  unless oozie_log_dir == '/var/log/oozie'
     # Delete default directory, if we aren't set to it
     directory '/var/log/oozie' do
       action :delete
@@ -130,7 +130,7 @@ if node['oozie'].key?('oozie_env')
     end
     # symlink
     link '/var/log/oozie' do
-      to node['oozie']['oozie_env']['oozie_log_dir']
+      to oozie_log_dir
     end
   end
 

--- a/recipes/spark.rb
+++ b/recipes/spark.rb
@@ -120,7 +120,7 @@ if node['spark'].key?('spark_env')
     end
     # symlink
     link '/var/log/spark' do
-      to node['spark']['spark_env']['spark_log_dir']
+      to spark_log_dir
     end
   end
 

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -139,7 +139,7 @@ if node['zookeeper'].key?('zookeeper_env')
     variables my_vars
   end
 
-  unless node['zookeeper']['zookeeper_env']['zookeeper_log_dir'] == '/var/log/zookeeper'
+  unless zookeeper_log_dir == '/var/log/zookeeper'
     # Delete default directory, if we aren't set to it
     directory '/var/log/zookeeper' do
       action :delete
@@ -147,7 +147,7 @@ if node['zookeeper'].key?('zookeeper_env')
     end
     # symlink
     link '/var/log/zookeeper' do
-      to node['zookeeper']['zookeeper_env']['zookeeper_log_dir']
+      to zookeeper_log_dir
     end
   end
 end # End zookeeper-env.sh


### PR DESCRIPTION
Use our derived variables instead of the attributes, directly. This resolves some issues where the *_log_dir attribute wasn't set, and we were deleting it.
