### PR TITLE
Fix JSVC_HOME in /etc/default/hadoop on HDP

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -214,6 +214,12 @@ else
   end
 end # End hadoop.tmp.dir
 
+# Some HDP versions ship broken init scripts/config
+execute 'fix-hdp-jsvc-path' do
+  command 'sed -i -e "/JSVC_HOME=/ s:libexec:lib:" /etc/default/hadoop'
+  only_if { node['hadoop']['distribution'] == 'hdp' }
+end
+
 # Update alternatives to point to our configuration
 execute 'update hadoop-conf alternatives' do
   command "update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/#{node['hadoop']['conf_dir']} 50"


### PR DESCRIPTION
For some reason, there's a mismatch between `bigtop-jsvc` package in `HDP-UTILS-1.1.0.19` repository and what gets shipped with the `hadoop` package on HDP. As such, let's just sed that bad boy.
