### PR TITLE
COOK-19 Configure hive.metastore.uris

### DIFF
--- a/attributes/hive.rb
+++ b/attributes/hive.rb
@@ -1,2 +1,3 @@
+default['hive']['hive_site']['hive.metastore.uris'] = 'thrift://localhost:9083'
 default['hive']['hive_site']['javax.jdo.option.ConnectionURL'] = 'jdbc:derby:;databaseName=/var/lib/hive/metastore/metastore_db;create=true'
 default['hive']['hive_site']['javax.jdo.option.ConnectionDriverName'] = 'org.apache.derby.jdbc.EmbeddedDriver'


### PR DESCRIPTION
Set a default for `hive.metastore.uris` to localhost