### PR TITLE
delete recursively when deleting default log directories for when the pa...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'berkshelf', '~> 3.0'
 gem 'foodcritic', '~> 3.0'
 
 gem 'chefspec', '~> 4.0'
+gem 'chef', '< 12.0'
 gem 'rspec', '~> 3.0'
 
 gem 'rubocop'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -124,6 +124,7 @@ end # End fair-scheduler.xml
       # Delete default directory, if we aren't set to it
       directory "/var/log/hadoop-#{log_dir}" do
         action :delete
+        recursive true
         not_if "test -L /var/log/hadoop-#{log_dir}"
       end
       # symlink

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -85,6 +85,7 @@ if node['hbase'].key?('hbase_env')
     # Delete default directory, if we aren't set to it
     directory '/var/log/hbase' do
       action :delete
+      recursive true
       not_if 'test -L /var/log/hbase'
     end
     # symlink

--- a/recipes/hive.rb
+++ b/recipes/hive.rb
@@ -129,6 +129,7 @@ if node['hive'].key?('hive_env')
     # Delete default directory, if we aren't set to it
     directory '/var/log/hive' do
       action :delete
+      recursive true
       not_if 'test -L /var/log/hive'
     end
     # symlink

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -126,6 +126,7 @@ if node['oozie'].key?('oozie_env')
     # Delete default directory, if we aren't set to it
     directory '/var/log/oozie' do
       action :delete
+      recursive true
       not_if 'test -L /var/log/oozie'
     end
     # symlink

--- a/recipes/spark.rb
+++ b/recipes/spark.rb
@@ -116,6 +116,7 @@ if node['spark'].key?('spark_env')
     # Delete default directory, if we aren't set to it
     directory '/var/log/spark' do
       action :delete
+      recursive true
       not_if 'test -L /var/log/spark'
     end
     # symlink

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -143,6 +143,7 @@ if node['zookeeper'].key?('zookeeper_env')
     # Delete default directory, if we aren't set to it
     directory '/var/log/zookeeper' do
       action :delete
+      recursive true
       not_if 'test -L /var/log/zookeeper'
     end
     # symlink


### PR DESCRIPTION
...ckage autostarts

- [x] when deleting default log directories, delete them recursively so that if any package autostarts happened, the logs will get deleted as intended instead of failing the chef run.