### PR TITLE
COOK-26 disable dpkg autostart

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 group :integration do
   cookbook 'minitest-handler'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,7 +20,7 @@
 module Hadoop
   # Helpers for Hadoop
   module Helpers
-    def policy_rc.d(cmd)
+    def policy_rcd(cmd)
       case cmd
       when 'disable'
         Chef::Log.info('Disabling package auto-start')

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: hadoop
+# Library:: helpers
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Hadoop
+  # Helpers for Hadoop
+  module Helpers
+    def policy_rc.d(cmd)
+      case cmd
+      when 'disable'
+        Chef::Log.info('Disabling package auto-start')
+        ::File.open('/usr/sbin/policy-rc.d', 'w', 0755) { |f| f.write('exit 101') }
+      when 'enable'
+        Chef::Log.info('Enabling package auto-start')
+        ::File.delete('/usr/sbin/policy-rc.d') if ::File.exist?('/usr/sbin/policy-rc.d')
+      else
+        Chef::Application.fatal!('The policy_rc.d method only accepts "disable" or "enable" as arguments')
+      end
+    end
+  end
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,7 +18,6 @@
 #
 
 module Hadoop
-  # Helpers for Hadoop
   module Helpers
     def policy_rcd(cmd)
       case cmd

--- a/recipes/flume_agent.rb
+++ b/recipes/flume_agent.rb
@@ -27,7 +27,20 @@ pkg =
   end
 
 package pkg do
-  action :install
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 service 'flume-agent' do

--- a/recipes/flume_agent.rb
+++ b/recipes/flume_agent.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: flume_agent
 #
-# Copyright © 2013-2014 Continuuity, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -19,9 +19,23 @@
 
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::hadoop_hdfs_checkconfig'
+pkg = 'hadoop-hdfs-datanode'
 
-package 'hadoop-hdfs-datanode' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 dfs_data_dirs =
@@ -55,8 +69,8 @@ dfs_data_dirs.split(',').each do |dir|
   end
 end
 
-service 'hadoop-hdfs-datanode' do
-  status_command 'service hadoop-hdfs-datanode status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_hdfs_datanode
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_hdfs_journalnode
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -22,8 +22,22 @@
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::hadoop_hdfs_checkconfig'
 
-package 'hadoop-hdfs-journalnode' do
-  action :install
+pkg = 'hadoop-hdfs-journalnode'
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 dfs_jn_edits_dirs =
@@ -43,8 +57,8 @@ dfs_jn_edits_dirs.split(',').each do |dir|
   end
 end
 
-service 'hadoop-hdfs-journalnode' do
-  status_command 'service hadoop-hdfs-journalnode status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_hdfs_namenode
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_hdfs_secondarynamenode
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -19,9 +19,23 @@
 
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::hadoop_hdfs_checkconfig'
+pkg = 'hadoop-hdfs-secondarynamenode'
 
-package 'hadoop-hdfs-secondarynamenode' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 fs_checkpoint_dirs =
@@ -64,8 +78,8 @@ snn_dirs.each do |dirs|
   end
 end
 
-service 'hadoop-hdfs-secondarynamenode' do
-  status_command 'service hadoop-hdfs-secondarynamenode status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hadoop_hdfs_zkfc.rb
+++ b/recipes/hadoop_hdfs_zkfc.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_hdfs_zkfc
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_hdfs_zkfc.rb
+++ b/recipes/hadoop_hdfs_zkfc.rb
@@ -20,13 +20,27 @@
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::hadoop_hdfs_ha_checkconfig'
 include_recipe 'hadoop::zookeeper'
+pkg = 'hadoop-hdfs-zkfc'
 
-package 'hadoop-hdfs-zkfc' do
-  action :install
+package pkg do
+  action :nothing
 end
 
-service 'hadoop-hdfs-zkfc' do
-  status_command 'service hadoop-hdfs-zkfc status'
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hadoop_mapreduce_historyserver.rb
+++ b/recipes/hadoop_mapreduce_historyserver.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_mapreduce_historyserver
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_mapreduce_historyserver.rb
+++ b/recipes/hadoop_mapreduce_historyserver.rb
@@ -18,13 +18,27 @@
 #
 
 include_recipe 'hadoop::default'
+pkg = 'hadoop-mapreduce-historyserver'
 
-package 'hadoop-mapreduce-historyserver' do
-  action :install
+package pkg do
+  action :nothing
 end
 
-service 'hadoop-mapreduce-historyserver' do
-  status_command 'service hadoop-mapreduce-historyserver status'
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hadoop_mapreduce_jobtracker.rb
+++ b/recipes/hadoop_mapreduce_jobtracker.rb
@@ -18,6 +18,7 @@
 #
 
 include_recipe 'hadoop::default'
+pkg = 'hadoop-0.20-mapreduce-jobtracker'
 
 # TODO: check for these and set them up
 # mapreduce.jobtracker.system.dir = #{hadoop_tmp_dir}/mapred/system (inside HDFS) = mapred.system.dir
@@ -45,14 +46,9 @@ mapred_local_dirs.split(',').each do |dir|
   end
 end
 
-# Only CDH supports a JobTracker package
-package 'hadoop-0.20-mapreduce-jobtracker' do
-  action :install
-  only_if { node['hadoop']['distribution'] == 'cdh' }
+package pkg do
+  action :nothing
 end
-
-### TODO: make this work
-
 
 # Hack to prevent auto-start of services, see COOK-26
 ruby_block "package-#{pkg}" do
@@ -65,10 +61,12 @@ ruby_block "package-#{pkg}" do
       policy_rcd('enable') if node['platform_family'] == 'debian'
     end
   end
+  # Only CDH supports a JobTracker package
+  only_if { node['hadoop']['distribution'] == 'cdh' }
 end
 
-service 'hadoop-0.20-mapreduce-jobtracker' do
-  status_command 'service hadoop-0.20-mapreduce-jobtracker status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
   only_if { node['hadoop']['distribution'] == 'cdh' }

--- a/recipes/hadoop_mapreduce_jobtracker.rb
+++ b/recipes/hadoop_mapreduce_jobtracker.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_mapreduce_jobtracker
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_mapreduce_jobtracker.rb
+++ b/recipes/hadoop_mapreduce_jobtracker.rb
@@ -51,6 +51,22 @@ package 'hadoop-0.20-mapreduce-jobtracker' do
   only_if { node['hadoop']['distribution'] == 'cdh' }
 end
 
+### TODO: make this work
+
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
 service 'hadoop-0.20-mapreduce-jobtracker' do
   status_command 'service hadoop-0.20-mapreduce-jobtracker status'
   supports [:restart => true, :reload => false, :status => true]

--- a/recipes/hadoop_mapreduce_tasktracker.rb
+++ b/recipes/hadoop_mapreduce_tasktracker.rb
@@ -46,6 +46,22 @@ package 'hadoop-0.20-mapreduce-tasktracker' do
   only_if { node['hadoop']['distribution'] == 'cdh' }
 end
 
+### TODO: make this work
+
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
 service 'hadoop-0.20-mapreduce-tasktracker' do
   status_command 'service hadoop-0.20-mapreduce-tasktracker status'
   supports [:restart => true, :reload => false, :status => true]

--- a/recipes/hadoop_mapreduce_tasktracker.rb
+++ b/recipes/hadoop_mapreduce_tasktracker.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_mapreduce_tasktracker
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -18,9 +18,23 @@
 #
 
 include_recipe 'hadoop::default'
+pkg = 'hadoop-yarn-nodemanager'
 
-package 'hadoop-yarn-nodemanager' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 # TODO: check for these and set them up
@@ -46,8 +60,8 @@ file '/usr/lib/hadoop-yarn/bin/container-executor' do
   mode '6050'
 end
 
-service 'hadoop-yarn-nodemanager' do
-  status_command 'service hadoop-yarn-nodemanager status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_yarn_nodemanager
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_yarn_proxyserver.rb
+++ b/recipes/hadoop_yarn_proxyserver.rb
@@ -24,13 +24,27 @@ if node['hadoop'].key?('yarn_site') && node['hadoop']['yarn_site'].key?('yarn.we
 else
   Chef::Application.fatal!("YARN Web Proxy must be configured! Set default['hadoop']['yarn_site']['yarn.web-proxy.address']}!")
 end
+pkg = 'hadoop-yarn-proxyserver'
 
-package 'hadoop-yarn-proxyserver' do
-  action :install
+package pkg do
+  action :nothing
 end
 
-service 'hadoop-yarn-proxyserver' do
-  status_command 'service hadoop-yarn-proxyserver status'
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hadoop_yarn_proxyserver.rb
+++ b/recipes/hadoop_yarn_proxyserver.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_yarn_proxyserver
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hadoop_yarn_resourcemanager
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -18,9 +18,23 @@
 #
 
 include_recipe 'hadoop::default'
+pkg = 'hadoop-yarn-resourcemanager'
 
-package 'hadoop-yarn-resourcemanager' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 # TODO: check for these and set them up
@@ -57,8 +71,8 @@ execute 'yarn-remote-app-log-dir' do
   action :nothing
 end
 
-service 'hadoop-yarn-resourcemanager' do
-  status_command 'service hadoop-yarn-resourcemanager status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hbase_master
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -19,9 +19,23 @@
 
 include_recipe 'hadoop::hbase'
 include_recipe 'hadoop::hbase_checkconfig'
+pkg = 'hbase-master'
 
-package 'hbase-master' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 # HBase can use a local directory or an HDFS directory for its rootdir...
@@ -69,8 +83,8 @@ execute 'hbase-bulkload-stagingdir' do
   action :nothing
 end
 
-service 'hbase-master' do
-  status_command 'service hbase-master status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -19,14 +19,28 @@
 
 include_recipe 'hadoop::hbase'
 include_recipe 'hadoop::hbase_checkconfig'
+pkg = 'hbase-regionserver'
 
-package 'hbase-regionserver' do
-  action :install
+package pkg do
+  action :nothing
 end
 
-service 'hbase-regionserver' do
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
+service pkg do
   supports [:restart => true, :reload => false, :status => true]
   # cdh4.4 init scripts do not return non-zero exit codes for status
-  status_command 'service hbase-regionserver status | grep -v "not running"'
+  status_command "service #{pkg} status | grep -v 'not running'"
   action :nothing
 end

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hbase_regionserver
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hbase_rest.rb
+++ b/recipes/hbase_rest.rb
@@ -18,13 +18,27 @@
 #
 
 include_recipe 'hadoop::hbase'
+pkg = 'hbase-rest'
 
-package 'hbase-rest' do
-  action :install
+package pkg do
+  action :nothing
 end
 
-service 'hbase-rest' do
-  status_command 'service hbase-rest status'
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hbase_rest.rb
+++ b/recipes/hbase_rest.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hbase_rest
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hbase_thrift.rb
+++ b/recipes/hbase_thrift.rb
@@ -18,13 +18,27 @@
 #
 
 include_recipe 'hadoop::hbase'
+pkg = 'hbase-thrift'
 
-package 'hbase-thrift' do
-  action :install
+package pkg do
+  action :nothing
 end
 
-service 'hbase-thrift' do
-  status_command 'service hbase-thrift status'
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hbase_thrift.rb
+++ b/recipes/hbase_thrift.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hbase_thrift
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -18,9 +18,23 @@
 #
 
 include_recipe 'hadoop::hive'
+pkg = 'hive-metastore'
 
-package 'hive-metastore' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 # Hive HDFS directories
@@ -62,8 +76,8 @@ execute 'hive-hdfs-warehousedir' do
   action :nothing
 end
 
-template '/etc/init.d/hive-metastore' do
-  source 'hive-metastore.erb'
+template "/etc/init.d/#{pkg}" do
+  source "#{pkg}.erb"
   mode '0755'
   owner 'root'
   group 'root'
@@ -71,8 +85,8 @@ template '/etc/init.d/hive-metastore' do
   only_if { node['hadoop']['distribution'] == 'hdp' }
 end
 
-service 'hive-metastore' do
-  status_command 'service hive-metastore status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hive_metastore
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hive_server.rb
+++ b/recipes/hive_server.rb
@@ -18,13 +18,27 @@
 #
 
 include_recipe 'hadoop::hive'
+pkg = 'hive-server'
 
-package 'hive-server' do
-  action :install
+package pkg do
+  action :nothing
 end
 
-service 'hive-server' do
-  status_command 'service hive-server status'
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
+end
+
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hive_server.rb
+++ b/recipes/hive_server.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hive_server
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -20,15 +20,29 @@
 include_recipe 'hadoop::hive'
 include_recipe 'hadoop::zookeeper'
 include_recipe 'hadoop::hive_checkconfig'
+pkg = 'hive-server2'
 
-package 'hive-server2' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
   # Hortonworks ships this as part of the hive package
   not_if { node['hadoop']['distribution'] == 'hdp' }
 end
 
-template '/etc/init.d/hive-server2' do
-  source 'hive-server2.erb'
+template "/etc/init.d/#{pkg}" do
+  source "#{pkg}.erb"
   mode '0755'
   owner 'root'
   group 'root'
@@ -55,8 +69,8 @@ if node['hive'].key?('jaas')
   end
 end # End jaas.conf
 
-service 'hive-server2' do
-  status_command 'service hive-server2 status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hive_server
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -19,9 +19,23 @@
 
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::oozie_client'
+pkg = 'oozie'
 
-package 'oozie' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 oozie_conf_dir = "/etc/oozie/#{node['oozie']['conf_dir']}"

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -66,8 +66,8 @@ when 'rhel'
   end
 end
 
-pkgs.each do |pkg|
-  package pkg do
+pkgs.each do |p|
+  package p do
     action :install
   end
 end
@@ -159,8 +159,8 @@ if node['oozie'].key?('oozie_env')
   end
 end # End oozie-env.sh
 
-service 'oozie' do
-  status_command 'service oozie status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: oozie
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -66,7 +66,7 @@ end
 if node['hadoop']['distribution'] == 'cdh'
   s_cmd = "service #{pkg}"
 else
-  s_cmd = 'true #'
+  s_cmd = 'true #' # Ends with # to make arguments a comment, versus part of command line
 end
 
 service 'spark-history-server' do

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: spark_historyserver
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -68,7 +68,6 @@ if node['hadoop']['distribution'] == 'cdh'
 else
   s_cmd = 'true #'
 end
-  
 
 service 'spark-history-server' do
   status_command "#{s_cmd} status"

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -18,15 +18,29 @@
 #
 
 include_recipe 'hadoop::spark'
+pkg = 'spark-master'
 
 if node['hadoop']['distribution'] == 'cdh'
 
-  package 'spark-master' do
-    action :install
+  package pkg do
+    action :nothing
   end
 
-  service 'spark-master' do
-    status_command 'service spark-master status'
+  # Hack to prevent auto-start of services, see COOK-26
+  ruby_block "package-#{pkg}" do
+    block do
+      begin
+        Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+        policy_rcd('disable') if node['platform_family'] == 'debian'
+        resources("package[#{pkg}]").run_action(:install)
+      ensure
+        policy_rcd('enable') if node['platform_family'] == 'debian'
+      end
+    end
+  end
+
+  service pkg do
+    status_command "service #{pkg} status"
     supports [:restart => true, :reload => false, :status => true]
     action :nothing
   end

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: spark_master
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/spark_worker.rb
+++ b/recipes/spark_worker.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: spark_worker
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/spark_worker.rb
+++ b/recipes/spark_worker.rb
@@ -18,15 +18,29 @@
 #
 
 include_recipe 'hadoop::spark'
+pkg = 'spark-worker'
 
 if node['hadoop']['distribution'] == 'cdh'
-  package 'spark-worker' do
-    action :install
-    only_if { node['hadoop']['distribution'] == 'cdh' }
+
+  package pkg do
+    action :nothing
   end
 
-  service 'spark-worker' do
-    status_command 'service spark-worker status'
+  # Hack to prevent auto-start of services, see COOK-26
+  ruby_block "package-#{pkg}" do
+    block do
+      begin
+        Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+        policy_rcd('disable') if node['platform_family'] == 'debian'
+        resources("package[#{pkg}]").run_action(:install)
+      ensure
+        policy_rcd('enable') if node['platform_family'] == 'debian'
+      end
+    end
+  end
+
+  service pkg do
+    status_command "service #{pkg} status"
     supports [:restart => true, :reload => false, :status => true]
     action :nothing
   end

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -19,9 +19,23 @@
 
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::zookeeper'
+pkg = 'zookeeper-server'
 
-package 'zookeeper-server' do
-  action :install
+package pkg do
+  action :nothing
+end
+
+# Hack to prevent auto-start of services, see COOK-26
+ruby_block "package-#{pkg}" do
+  block do
+    begin
+      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
+      policy_rcd('disable') if node['platform_family'] == 'debian'
+      resources("package[#{pkg}]").run_action(:install)
+    ensure
+      policy_rcd('enable') if node['platform_family'] == 'debian'
+    end
+  end
 end
 
 # HDP 2.0.11.0 (maybe others) doesn't create zookeeper group
@@ -183,8 +197,8 @@ if node['hadoop']['distribution'] == 'hdp' &&
   end
 end # HDP 2.1 hack
 
-service 'zookeeper-server' do
-  status_command 'service zookeeper-server status'
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: zookeeper_server
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/flume_agent_spec.rb
+++ b/spec/flume_agent_spec.rb
@@ -8,8 +8,12 @@ describe 'hadoop::flume_agent' do
       end.converge(described_recipe)
     end
 
-    it 'install flume-agent package' do
-      expect(chef_run).to install_package('flume-agent')
+    it 'does not install flume-agent package' do
+      expect(chef_run).not_to install_package('flume-agent')
+    end
+
+    it 'runs package-flume-agent ruby_block' do
+      expect(chef_run).to run_ruby_block('package-flume-agent')
     end
 
     it 'creates flume-agent service resource, but does not run it' do
@@ -25,8 +29,12 @@ describe 'hadoop::flume_agent' do
       end.converge(described_recipe)
     end
 
-    it 'install flume-ng package' do
-      expect(chef_run).to install_package('flume-ng-agent')
+    it 'does not install flume-ng package' do
+      expect(chef_run).not_to install_package('flume-ng-agent')
+    end
+
+    it 'runs package-flume-ng-agent ruby_block' do
+      expect(chef_run).to run_ruby_block('package-flume-ng-agent')
     end
   end
 end

--- a/spec/hadoop_hdfs_datanode_spec.rb
+++ b/spec/hadoop_hdfs_datanode_spec.rb
@@ -8,9 +8,23 @@ describe 'hadoop::hadoop_hdfs_datanode' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-hdfs-datanode'
 
-    it 'install hadoop-hdfs-datanode package' do
-      expect(chef_run).to install_package('hadoop-hdfs-datanode')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates HDFS data dir' do
@@ -18,10 +32,6 @@ describe 'hadoop::hadoop_hdfs_datanode' do
         user: 'hdfs',
         group: 'hdfs'
       )
-    end
-
-    it 'creates hadoop-hdfs-datanode service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-hdfs-datanode')
     end
   end
 end

--- a/spec/hadoop_hdfs_journalnode_spec.rb
+++ b/spec/hadoop_hdfs_journalnode_spec.rb
@@ -9,9 +9,23 @@ describe 'hadoop::hadoop_hdfs_journalnode' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-hdfs-journalnode'
 
-    it 'install hadoop-hdfs-datanode package' do
-      expect(chef_run).to install_package('hadoop-hdfs-journalnode')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates HDFS journalnode edits dir' do
@@ -19,10 +33,6 @@ describe 'hadoop::hadoop_hdfs_journalnode' do
         user: 'hdfs',
         group: 'hdfs'
       )
-    end
-
-    it 'creates hadoop-hdfs-journalnode service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-hdfs-journalnode')
     end
   end
 end

--- a/spec/hadoop_hdfs_namenode_spec.rb
+++ b/spec/hadoop_hdfs_namenode_spec.rb
@@ -8,9 +8,23 @@ describe 'hadoop::hadoop_hdfs_namenode' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-hdfs-namenode'
 
-    it 'install hadoop-hdfs-namenode package' do
-      expect(chef_run).to install_package('hadoop-hdfs-namenode')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates HDFS name dir' do
@@ -22,15 +36,6 @@ describe 'hadoop::hadoop_hdfs_namenode' do
 
     it 'creates hdfs-namenode-format execute resource, but does not run it' do
       expect(chef_run).to_not run_execute('hdfs-namenode-format').with(user: 'hdfs')
-    end
-
-    it 'creates hadoop-hdfs-namenode service resource, but does not run it' do
-      expect(chef_run).to_not disable_service('hadoop-hdfs-namenode')
-      expect(chef_run).to_not enable_service('hadoop-hdfs-namenode')
-      expect(chef_run).to_not reload_service('hadoop-hdfs-namenode')
-      expect(chef_run).to_not restart_service('hadoop-hdfs-namenode')
-      expect(chef_run).to_not start_service('hadoop-hdfs-namenode')
-      expect(chef_run).to_not stop_service('hadoop-hdfs-namenode')
     end
   end
 end

--- a/spec/hadoop_hdfs_secondarynamenode_spec.rb
+++ b/spec/hadoop_hdfs_secondarynamenode_spec.rb
@@ -10,9 +10,23 @@ describe 'hadoop::hadoop_hdfs_secondarynamenode' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-hdfs-secondarynamenode'
 
-    it 'install hadoop-hdfs-secondarynamenode package' do
-      expect(chef_run).to install_package('hadoop-hdfs-secondarynamenode')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates HDFS checkpoint dirs' do
@@ -24,10 +38,6 @@ describe 'hadoop::hadoop_hdfs_secondarynamenode' do
         user: 'hdfs',
         group: 'hdfs'
       )
-    end
-
-    it 'creates hadoop-hdfs-secondarynamenode service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-hdfs-secondarynamenode')
     end
   end
 end

--- a/spec/hadoop_hdfs_zkfc_spec.rb
+++ b/spec/hadoop_hdfs_zkfc_spec.rb
@@ -11,13 +11,23 @@ describe 'hadoop::hadoop_hdfs_zkfc' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-hdfs-zkfc'
 
-    it 'install hadoop-hdfs-zkfc package' do
-      expect(chef_run).to install_package('hadoop-hdfs-zkfc')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hadoop-hdfs-zkfc service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-hdfs-zkfc')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/hadoop_mapreduce_historyserver_spec.rb
+++ b/spec/hadoop_mapreduce_historyserver_spec.rb
@@ -8,13 +8,23 @@ describe 'hadoop::hadoop_mapreduce_historyserver' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-mapreduce-historyserver'
 
-    it 'installs hadoop-mapreduce-historyserver package' do
-      expect(chef_run).to install_package('hadoop-mapreduce-historyserver')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hadoop-mapreduce-historyserver service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-mapreduce-historyserver')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/hadoop_mapreduce_jobtracker_spec.rb
+++ b/spec/hadoop_mapreduce_jobtracker_spec.rb
@@ -9,9 +9,23 @@ describe 'hadoop::hadoop_mapreduce_jobtracker' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-0.20-mapreduce-jobtracker'
 
-    it 'installs hadoop-0.20-mapreduce-jobtracker package' do
-      expect(chef_run).to install_package('hadoop-0.20-mapreduce-jobtracker')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates local dir' do
@@ -19,9 +33,6 @@ describe 'hadoop::hadoop_mapreduce_jobtracker' do
         user: 'mapred',
         group: 'mapred'
       )
-    end
-    it 'creates hadoop-0.20-mapreduce-jobtracker service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-0.20-mapreduce-jobtracker')
     end
   end
 
@@ -32,9 +43,10 @@ describe 'hadoop::hadoop_mapreduce_jobtracker' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-0.20-mapreduce-jobtracker'
 
-    it 'does not install hadoop-0.20-mapreduce-jobtracker package' do
-      expect(chef_run).not_to install_package('hadoop-0.20-mapreduce-jobtracker')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
   end
 end

--- a/spec/hadoop_mapreduce_tasktracker_spec.rb
+++ b/spec/hadoop_mapreduce_tasktracker_spec.rb
@@ -9,13 +9,23 @@ describe 'hadoop::hadoop_mapreduce_tasktracker' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-0.20-mapreduce-tasktracker'
 
-    it 'installs hadoop-0.20-mapreduce-tasktracker package' do
-      expect(chef_run).to install_package('hadoop-0.20-mapreduce-tasktracker')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hadoop-0.20-mapreduce-tasktracker service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-0.20-mapreduce-tasktracker')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 

--- a/spec/hadoop_yarn_nodemanager_spec.rb
+++ b/spec/hadoop_yarn_nodemanager_spec.rb
@@ -8,9 +8,23 @@ describe 'hadoop::hadoop_yarn_nodemanager' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-yarn-nodemanager'
 
-    it 'install hadoop-yarn-nodemanager package' do
-      expect(chef_run).to install_package('hadoop-yarn-nodemanager')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'ensures /usr/lib/hadoop-yarn/bin/container-executor has proper permissions' do
@@ -19,10 +33,6 @@ describe 'hadoop::hadoop_yarn_nodemanager' do
         group: 'yarn',
         mode: '6050'
       )
-    end
-
-    it 'creates hadoop-yarn-nodemanager service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-yarn-nodemanager')
     end
   end
 end

--- a/spec/hadoop_yarn_proxyserver_spec.rb
+++ b/spec/hadoop_yarn_proxyserver_spec.rb
@@ -9,13 +9,23 @@ describe 'hadoop::hadoop_yarn_proxyserver' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-yarn-proxyserver'
 
-    it 'install hadoop-yarn-proxyserver package' do
-      expect(chef_run).to install_package('hadoop-yarn-proxyserver')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hadoop-yarn-proxyserver service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-yarn-proxyserver')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/hadoop_yarn_resourcemanager_spec.rb
+++ b/spec/hadoop_yarn_resourcemanager_spec.rb
@@ -8,9 +8,23 @@ describe 'hadoop::hadoop_yarn_resourcemanager' do
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-yarn-resourcemanager'
 
-    it 'install hadoop-yarn-resourcemanager package' do
-      expect(chef_run).to install_package('hadoop-yarn-resourcemanager')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates hdfs-tmpdir execute resource, but does not run it' do
@@ -19,10 +33,6 @@ describe 'hadoop::hadoop_yarn_resourcemanager' do
 
     it 'creates yarn-remote-app-log-dir execute resource, but does not run it' do
       expect(chef_run).to_not run_execute('yarn-remote-app-log-dir').with(user: 'hdfs')
-    end
-
-    it 'creates hadoop-yarn-resourcemanager service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hadoop-yarn-resourcemanager')
     end
   end
 end

--- a/spec/hbase_master_spec.rb
+++ b/spec/hbase_master_spec.rb
@@ -12,13 +12,23 @@ describe 'hadoop::hbase_master' do
         stub_command('update-alternatives --display hbase-conf | grep best | awk \'{print $5}\' | grep /etc/hbase/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hbase-master'
 
-    it 'install hbase-master package' do
-      expect(chef_run).to install_package('hbase-master')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hbase-master service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hbase-master')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates hbase-hdfs-rootdir execute resource, but does not run it' do

--- a/spec/hbase_regionserver_spec.rb
+++ b/spec/hbase_regionserver_spec.rb
@@ -12,13 +12,23 @@ describe 'hadoop::hbase_regionserver' do
         stub_command('update-alternatives --display hbase-conf | grep best | awk \'{print $5}\' | grep /etc/hbase/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hbase-regionserver'
 
-    it 'install hbase-regionserver package' do
-      expect(chef_run).to install_package('hbase-regionserver')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hbase-regionserver service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hbase-regionserver')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/hbase_rest_spec.rb
+++ b/spec/hbase_rest_spec.rb
@@ -12,13 +12,23 @@ describe 'hadoop::hbase_rest' do
         stub_command('update-alternatives --display hbase-conf | grep best | awk \'{print $5}\' | grep /etc/hbase/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hbase-rest'
 
-    it 'install hbase-rest package' do
-      expect(chef_run).to install_package('hbase-rest')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hbase-rest service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hbase-rest')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/hbase_thrift_spec.rb
+++ b/spec/hbase_thrift_spec.rb
@@ -12,13 +12,23 @@ describe 'hadoop::hbase_thrift' do
         stub_command('update-alternatives --display hbase-conf | grep best | awk \'{print $5}\' | grep /etc/hbase/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hbase-thrift'
 
-    it 'install hbase-thrift package' do
-      expect(chef_run).to install_package('hbase-thrift')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hbase-thrift service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hbase-thrift')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/hive_metastore_spec.rb
+++ b/spec/hive_metastore_spec.rb
@@ -8,21 +8,31 @@ describe 'hadoop::hive_metastore' do
         stub_command('update-alternatives --display hive-conf | grep best | awk \'{print $5}\' | grep /etc/hive/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hive-metastore'
 
-    it 'install hive-metastore package' do
-      expect(chef_run).to install_package('hive-metastore')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates /etc/init.d/hive-metastore from template' do
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
+    end
+
+    it "creates /etc/init.d/#{pkg} from template" do
       expect(chef_run).to create_template('/etc/init.d/hive-metastore')
     end
 
     it 'does not run execute[hive-hdfs-warehousedir]' do
       expect(chef_run).not_to run_execute('hive-hdfs-warehousedir')
-    end
-
-    it 'creates hive-metastore service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hive-metastore')
     end
   end
 end

--- a/spec/hive_server2_spec.rb
+++ b/spec/hive_server2_spec.rb
@@ -10,6 +10,20 @@ describe 'hadoop::hive_server2' do
         stub_command('update-alternatives --display hive-conf | grep best | awk \'{print $5}\' | grep /etc/hive/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hive-server2'
+
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
+    end
 
     it 'does not install hive-server2 package' do
       expect(chef_run).not_to install_package('hive-server2')
@@ -18,11 +32,8 @@ describe 'hadoop::hive_server2' do
     it 'creates /etc/init.d/hive-server2 from template' do
       expect(chef_run).to create_template('/etc/init.d/hive-server2')
     end
-
-    it 'creates hive-server2 service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hive-server2')
-    end
   end
+
   context 'on Centos 6.5 x86_64 with CDH' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
@@ -33,9 +44,23 @@ describe 'hadoop::hive_server2' do
         stub_command('update-alternatives --display hive-conf | grep best | awk \'{print $5}\' | grep /etc/hive/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hive-server2'
 
-    it 'install hive-server2 package' do
-      expect(chef_run).to install_package('hive-server2')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/hive_server_spec.rb
+++ b/spec/hive_server_spec.rb
@@ -8,13 +8,23 @@ describe 'hadoop::hive_server' do
         stub_command('update-alternatives --display hive-conf | grep best | awk \'{print $5}\' | grep /etc/hive/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hive-server'
 
-    it 'install hive-server package' do
-      expect(chef_run).to install_package('hive-server')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates hive-server service resource, but does not run it' do
-      expect(chef_run).to_not start_service('hive-server')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/oozie_spec.rb
+++ b/spec/oozie_spec.rb
@@ -11,9 +11,23 @@ describe 'hadoop::oozie' do
         stub_command('update-alternatives --display oozie-conf | grep best | awk \'{print $5}\' | grep /etc/oozie/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'oozie'
 
-    it 'install oozie package' do
-      expect(chef_run).to install_package('oozie')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates oozie conf_dir' do
@@ -67,10 +81,6 @@ describe 'hadoop::oozie' do
     it 'creates /var/log/oozie symlink' do
       link = chef_run.link('/var/log/oozie')
       expect(link).to link_to('/data/log/oozie')
-    end
-
-    it 'creates oozie service resource, but does not run it' do
-      expect(chef_run).to_not start_service('oozie')
     end
 
     it 'runs execute[update oozie-conf alternatives]' do

--- a/spec/oozie_spec.rb
+++ b/spec/oozie_spec.rb
@@ -50,13 +50,13 @@ describe 'hadoop::oozie' do
       expect(chef_run).to install_package('unzip')
     end
 
-    %w(mysql-connector-java postgresql-jdbc).each do |pkg|
-      it "install #{pkg} package" do
-        expect(chef_run).to install_package(pkg)
+    %w(mysql-connector-java postgresql-jdbc).each do |p|
+      it "install #{p} package" do
+        expect(chef_run).to install_package(p)
       end
-      it "link #{pkg}.jar" do
-        link = chef_run.link("/var/lib/oozie/#{pkg}.jar")
-        expect(link).to link_to("/usr/share/java/#{pkg}.jar")
+      it "link #{p}.jar" do
+        link = chef_run.link("/var/lib/oozie/#{p}.jar")
+        expect(link).to link_to("/usr/share/java/#{p}.jar")
       end
     end
 

--- a/spec/spark_historyserver_spec.rb
+++ b/spec/spark_historyserver_spec.rb
@@ -10,9 +10,19 @@ describe 'hadoop::spark_historyserver' do
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'spark-historyserver'
 
-    it 'does not install spark-history-server package' do
-      expect(chef_run).not_to install_package('spark-history-server')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates hdfs-spark-userdir execute resource, but does not run it' do
@@ -34,13 +44,23 @@ describe 'hadoop::spark_historyserver' do
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'spark-history-server'
 
-    it 'installs spark-history-server package' do
-      expect(chef_run).to install_package('spark-history-server')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates spark-history-server service resource, but does not run it' do
-      expect(chef_run).to_not start_service('spark-history-server')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/spark_master_spec.rb
+++ b/spec/spark_master_spec.rb
@@ -26,13 +26,23 @@ describe 'hadoop::spark_master' do
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'spark-master'
 
-    it 'installs spark-master package' do
-      expect(chef_run).to install_package('spark-master')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates spark-master service resource, but does not run it' do
-      expect(chef_run).to_not start_service('spark-master')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
   end
 end

--- a/spec/spark_worker_spec.rb
+++ b/spec/spark_worker_spec.rb
@@ -31,13 +31,23 @@ describe 'hadoop::spark_worker' do
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'spark-worker'
 
-    it 'installs spark-worker package' do
-      expect(chef_run).to install_package('spark-worker')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
 
-    it 'creates spark-worker service resource, but does not run it' do
-      expect(chef_run).to_not start_service('spark-worker')
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates /var/run/spark/work directory' do

--- a/spec/zookeeper_server_spec.rb
+++ b/spec/zookeeper_server_spec.rb
@@ -14,9 +14,23 @@ describe 'hadoop::zookeeper_server' do
         stub_command('test -e /usr/lib/bigtop-utils/bigtop-detect-javahome').and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'zookeeper-server'
 
-    it 'install zookeeper-server package' do
-      expect(chef_run).to install_package('zookeeper-server')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
+    end
+
+    it "runs package-#{pkg} ruby_block" do
+      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    it "creates #{pkg} service resource, but does not run it" do
+      expect(chef_run).to_not disable_service(pkg)
+      expect(chef_run).to_not enable_service(pkg)
+      expect(chef_run).to_not reload_service(pkg)
+      expect(chef_run).to_not restart_service(pkg)
+      expect(chef_run).to_not start_service(pkg)
+      expect(chef_run).to_not stop_service(pkg)
     end
 
     it 'creates zookeeper conf_dir' do
@@ -86,10 +100,6 @@ describe 'hadoop::zookeeper_server' do
 
     it 'logs hdp-2.1 release engineering fix' do
       expect(chef_run).to write_log('Performing workaround for broken zookeeper-server init script on HDP 2.1')
-    end
-
-    it 'creates zookeeper-server service resource, but does not run it' do
-      expect(chef_run).to_not start_service('zookeeper-server')
     end
 
     it 'runs execute[update zookeeper-conf alternatives]' do


### PR DESCRIPTION
- Introduced policy_rcd method to enable/disable auto-starting packages on debian-based distributions
- Update recipes to use a ruby_block to policy_rcd before/after package