### PR TITLE
Prefix internal recipe names with underscore

### DIFF
--- a/recipes/_hadoop_hdfs_checkconfig.rb
+++ b/recipes/_hadoop_hdfs_checkconfig.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: hadoop
-# Recipe:: hadoop_hdfs_checkconfig
+# Recipe:: _hadoop_hdfs_checkconfig
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/_hadoop_hdfs_ha_checkconfig.rb
+++ b/recipes/_hadoop_hdfs_ha_checkconfig.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: hadoop
-# Recipe:: hadoop_hdfs_ha_checkconfig
+# Recipe:: _hadoop_hdfs_ha_checkconfig
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/_hbase_checkconfig.rb
+++ b/recipes/_hbase_checkconfig.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: hadoop
-# Recipe:: hbase_checkconfig
+# Recipe:: _hbase_checkconfig
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/_hive_checkconfig.rb
+++ b/recipes/_hive_checkconfig.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: hadoop
-# Recipe:: hive_checkconfig
+# Recipe:: _hive_checkconfig
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/_zookeeper_checkconfig.rb
+++ b/recipes/_zookeeper_checkconfig.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: hadoop
-# Recipe:: zookeeper_checkconfig
+# Recipe:: _zookeeper_checkconfig
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop::hadoop_hdfs_checkconfig'
+include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
 pkg = 'hadoop-hdfs-datanode'
 
 package pkg do

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -20,7 +20,7 @@
 # http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/HDFSHighAvailabilityWithQJM.html
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop::hadoop_hdfs_checkconfig'
+include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
 
 pkg = 'hadoop-hdfs-journalnode'
 package pkg do

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop::hadoop_hdfs_checkconfig'
+include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
 pkg = 'hadoop-hdfs-namenode'
 
 package pkg do

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop::hadoop_hdfs_checkconfig'
+include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
 pkg = 'hadoop-hdfs-secondarynamenode'
 
 package pkg do

--- a/recipes/hadoop_hdfs_zkfc.rb
+++ b/recipes/hadoop_hdfs_zkfc.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop::hadoop_hdfs_ha_checkconfig'
+include_recipe 'hadoop::_hadoop_hdfs_ha_checkconfig'
 include_recipe 'hadoop::zookeeper'
 pkg = 'hadoop-hdfs-zkfc'
 

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::hbase'
-include_recipe 'hadoop::hbase_checkconfig'
+include_recipe 'hadoop::_hbase_checkconfig'
 pkg = 'hbase-master'
 
 package pkg do

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::hbase'
-include_recipe 'hadoop::hbase_checkconfig'
+include_recipe 'hadoop::_hbase_checkconfig'
 pkg = 'hbase-regionserver'
 
 package pkg do

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -18,8 +18,8 @@
 #
 
 include_recipe 'hadoop::hive'
+include_recipe 'hadoop::_hive_checkconfig'
 include_recipe 'hadoop::zookeeper'
-include_recipe 'hadoop::hive_checkconfig'
 pkg = 'hive-server2'
 
 package pkg do

--- a/recipes/zookeeper.rb
+++ b/recipes/zookeeper.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::repo'
-include_recipe 'hadoop::zookeeper_checkconfig'
+include_recipe 'hadoop::_zookeeper_checkconfig'
 
 package 'zookeeper' do
   action :install


### PR DESCRIPTION
This makes it a bit easier to read the list of recipes that a user can directly include.