### PR TITLE
Support yarn.app.mapreduce.am.staging-dir correctly

### DIFF
--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -37,9 +37,6 @@ ruby_block "package-#{pkg}" do
   end
 end
 
-# TODO: check for these and set them up
-# yarn.app.mapreduce.am.staging-dir = /tmp/hadoop-yarn/staging
-
 %w(yarn.nodemanager.local-dirs yarn.nodemanager.log-dirs).each do |opt|
   next unless node['hadoop'].key?('yarn_site') && node['hadoop']['yarn_site'].key?(opt)
   node['hadoop']['yarn_site'][opt].split(',').each do |dir|


### PR DESCRIPTION
Cleaning up a TODO item. This allows running Mapreduce jobs on secure clusters via Hive, which need the JHS, which will write to a subdirectory of this PATH.