### PR TITLE
Test Ruby 2.0.0 and 2.1.4 and restrict Chef version on Ruby < 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,8 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1.4
 cache: bundler
 sudo: false
 bundler_args: --jobs 7 --without docs integration

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ gem 'foodcritic', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
-gem 'chef', '< 12.0'
-
+gem 'chef', '< 12.0' if RUBY_VERSION.to_f < 2.0
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'


### PR DESCRIPTION
Travis-only updates. If the tests pass, this can be merged.