### PR TITLE
COOK-30 Fix YARN staging

### DIFF
--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -86,7 +86,7 @@ execute 'yarn-app-mapreduce-am-staging-dir' do
   timeout 300
   user 'hdfs'
   group 'hdfs'
-  not_if "hdfs dfs -test -d #{am_staging_dir}", :user => 'hdfs'
+  not_if "hdfs dfs -test -d #{am_staging_dir} && [ \"$(hdfs dfs -ls #{::File.dirname(am_staging_dir)} | grep #{am_staging_dir} | awk '{print $1,$3,$4}')\" == \"drwxrwxrwt yarn hadoop\"]", :user => 'hdfs'
   action :nothing
 end
 

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -86,7 +86,7 @@ execute 'yarn-app-mapreduce-am-staging-dir' do
   timeout 300
   user 'hdfs'
   group 'hdfs'
-  not_if "hdfs dfs -test -d #{remote_log_dir}", :user => 'hdfs'
+  not_if "hdfs dfs -test -d #{am_staging_dir}", :user => 'hdfs'
   action :nothing
 end
 

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -86,7 +86,7 @@ execute 'yarn-app-mapreduce-am-staging-dir' do
   timeout 300
   user 'hdfs'
   group 'hdfs'
-  not_if "hdfs dfs -test -d #{am_staging_dir} && [ \"$(hdfs dfs -ls #{::File.dirname(am_staging_dir)} | grep #{am_staging_dir} | awk '{print $1,$3,$4}')\" == \"drwxrwxrwt yarn hadoop\"]", :user => 'hdfs'
+  not_if "hdfs dfs -ls #{::File.dirname(am_staging_dir)} | grep #{am_staging_dir} | awk '{print $1,$3,$4}' | grep 'drwxrwxrwt yarn hadoop'", :user => 'hdfs'
   action :nothing
 end
 


### PR DESCRIPTION
This resolves an issue where YARN's staging directory didn't get the correct permissions applied, or in some cases, wasn't created.