### PR TITLE
Support HDP 2.2.4.2 and the new repository layout

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
   require_chef_omnibus: true
 
 platforms:
-  - name: centos-6.5
+  - name: centos-6.6
     attributes:
       hadoop:
         hdfs_site:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -218,7 +218,10 @@ end # End hadoop.tmp.dir
 # Some HDP versions ship broken init scripts/config
 execute 'fix-hdp-jsvc-path' do
   command 'sed -i -e "/JSVC_HOME=/ s:libexec:lib:" /etc/default/hadoop'
-  only_if { node['hadoop']['distribution'] == 'hdp' }
+  only_if do
+    node['hadoop']['distribution'] == 'hdp' && (node['hadoop']['distribution_version'] == '2' || \
+                                                node['hadoop']['distribution_version'].to_f == '2.1')
+  end
 end
 
 # Update alternatives to point to our configuration

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -219,8 +219,8 @@ end # End hadoop.tmp.dir
 execute 'fix-hdp-jsvc-path' do
   command 'sed -i -e "/JSVC_HOME=/ s:libexec:lib:" /etc/default/hadoop'
   only_if do
-    node['hadoop']['distribution'] == 'hdp' && (node['hadoop']['distribution_version'] == '2' || \
-                                                node['hadoop']['distribution_version'].to_f == '2.1')
+    node['hadoop']['distribution'] == 'hdp' && (node['hadoop']['distribution_version'].to_s == '2' || \
+                                                node['hadoop']['distribution_version'].to_f == 2.1)
   end
 end
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: repo
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ when 'hdp'
   when '2.0'
     hdp_version = '2.0.4.0'
     hdp_update_version = '2.0.13.0'
-  when '2.1.1.0', '2.0.4.0'
+  when '2.0.4.0', '2.1.1.0', '2.2.0.0'
     hdp_version = node['hadoop']['distribution_version']
     hdp_update_version = nil
   when '2.1.2.0', '2.1.2.1', '2.1.3.0', '2.1.4.0', '2.1.5.0', '2.1.7.0'
@@ -56,9 +56,9 @@ when 'hdp'
   when '2.1'
     hdp_version = '2.1.1.0'
     hdp_update_version = '2.1.7.0'
-  when '2.2.0.0', '2.2', '2'
+  when '2.2.4.2', '2.2', '2'
     hdp_version = '2.2.0.0'
-    hdp_update_version = nil
+    hdp_update_version = '2.2.4.2'
   else
     Chef::Application.fatal!('This cookbook only supports HDP 2.x')
   end
@@ -119,7 +119,16 @@ when 'hdp'
       os = "#{node['platform']}12"
     end
     hdp_update_version = hdp_version if hdp_update_version.nil?
-    apt_repo_url = node['hadoop']['apt_repo_url'] ? node['hadoop']['apt_repo_url'] : "#{apt_base_url}/#{os}/#{hdp_update_version}"
+    hdp_apt_repo_path =
+      case hdp_update_version
+      when '2.2.0.0'
+        "2.x/GA/#{hdp_update_version}"
+      when '2.2.4.2'
+        "2.x/updates/#{hdp_update_version}"
+      else
+        hdp_update_version
+      end
+    apt_repo_url = node['hadoop']['apt_repo_url'] ? node['hadoop']['apt_repo_url'] : "#{apt_base_url}/#{os}/#{hdp_apt_repo_path}"
     # Hortonworks don't know how to provide a key, but we do
     apt_repo_key_url = node['hadoop']['apt_repo_key_url'] ? node['hadoop']['apt_repo_key_url'] : "#{apt_base_url}/centos6/#{key}/#{key}-Jenkins"
 


### PR DESCRIPTION
- Use CentOS 6.6 in kitchen
- Only execute `fix-hdp-jsvc-path` on HDP 2.1
- Bump to `2.2.4.2` for version `2` and `2.2`
- Use new HDP repository layout