### PR TITLE
COOK-35 Allow setting limits.d via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ default['zookeeper']['conf_dir'] = node['hadoop']['conf_dir']
 
 # limits.d settings
 default['hadoop']['limits']['nofile'] = '32768'
-default['hadoop']['limits']['noproc'] = '65536'
+default['hadoop']['limits']['nproc'] = '65536'
 
 ###
 # core-site.xml settings

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,10 @@ default['spark']['conf_dir'] = node['hadoop']['conf_dir']
 default['tez']['conf_dir'] = node['hadoop']['conf_dir']
 default['zookeeper']['conf_dir'] = node['hadoop']['conf_dir']
 
+# limits.d settings
+default['hadoop']['limits']['nofile'] = '32768'
+default['hadoop']['limits']['noproc'] = '65536'
+
 ###
 # core-site.xml settings
 ###

--- a/attributes/hbase.rb
+++ b/attributes/hbase.rb
@@ -4,3 +4,6 @@ default['hbase']['hbase_site']['hbase.rootdir'] = "#{node['hadoop']['core_site']
 default['hbase']['hbase_policy']['security.client.protocol.acl'] = '*'
 default['hbase']['hbase_policy']['security.admin.protocol.acl'] = '*'
 default['hbase']['hbase_policy']['security.masterregion.protocol.acl'] = '*'
+# limits.d settings
+default['hbase']['limits']['nofile'] = '32768'
+default['hbase']['limits']['memlock'] = 'unlimited'

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "yum": ">= 3.0",
     "apt": ">= 0.0.0",
-    "sysctl": ">= 0.0.0"
+    "sysctl": ">= 0.0.0",
+    "limits": ">= 0.0.0"
   },
   "recommendations": {
     "java": "~> 1.21"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ version          '1.13.1'
 depends 'yum', '>= 3.0'
 depends 'apt'
 depends 'sysctl'
+depends 'limits'
 
 recommends 'java', '~> 1.21'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -226,15 +226,19 @@ end
 
 # limits.d settings
 if node['hadoop'].key?('limits') && !node['hadoop']['limits'].empty?
-  %w(hdfs mapred).each do |u|
+  %w(hdfs mapred yarn).each do |u|
     l = []
     node['hadoop']['limits'].each do |k, v|
       l << { domain: u, type: '-', item: k, value: v }
     end
 
     limits_config u do
+      action :create
       limits l
     end
+  end
+  limits_config 'mapreduce' do
+    action :delete
   end
 end # End limits.d
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -224,6 +224,20 @@ execute 'fix-hdp-jsvc-path' do
   end
 end
 
+# limits.d settings
+if node['hadoop'].key?('limits') && !node['hadoop']['limits'].empty?
+  %w(hdfs mapred).each do |u|
+    l = []
+    node['hadoop']['limits'].each do |k, v|
+      l << { domain: u, type: '-', item: k, value: v }
+    end
+
+    limits_config u do
+      limits l
+    end
+  end
+end # End limits.d
+
 # Update alternatives to point to our configuration
 execute 'update hadoop-conf alternatives' do
   command "update-alternatives --install /etc/hadoop/conf hadoop-conf /etc/hadoop/#{node['hadoop']['conf_dir']} 50"

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -136,6 +136,17 @@ if node['hbase'].key?('jaas')
   end
 end # End jaas.conf
 
+# limits.d settings
+if node['hbase'].key?('limits') && !node['hbase']['limits'].empty?
+  l = []
+  node['hbase']['limits'].each do |k, v|
+    l << { domain: 'hbase', type: 'hard', item: k, value: v }
+  end
+  limits_config 'hbase' do
+    limits l
+  end
+end # End limits.d
+
 # Update alternatives to point to our configuration
 execute 'update hbase-conf alternatives' do
   command "update-alternatives --install /etc/hbase/conf hbase-conf /etc/hbase/#{node['hbase']['conf_dir']} 50"

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -140,7 +140,7 @@ end # End jaas.conf
 if node['hbase'].key?('limits') && !node['hbase']['limits'].empty?
   l = []
   node['hbase']['limits'].each do |k, v|
-    l << { domain: 'hbase', type: 'hard', item: k, value: v }
+    l << { domain: 'hbase', type: '-', item: k, value: v }
   end
   limits_config 'hbase' do
     limits l

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -125,6 +125,12 @@ describe 'hadoop::default' do
       expect(chef_run).to run_execute('fix-hdp-jsvc-path')
     end
 
+    it 'sets limits for hdfs/mapred' do
+      %w(hdfs mapred).each do |u|
+        expect(chef_run).to create_limits_config(u)
+      end
+    end
+
     it 'runs execute[update hadoop-conf alternatives]' do
       expect(chef_run).to run_execute('update hadoop-conf alternatives')
     end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -125,10 +125,14 @@ describe 'hadoop::default' do
       expect(chef_run).to run_execute('fix-hdp-jsvc-path')
     end
 
-    it 'sets limits for hdfs/mapred' do
-      %w(hdfs mapred).each do |u|
+    it 'sets limits for hdfs/mapred/yarn' do
+      %w(hdfs mapred yarn).each do |u|
         expect(chef_run).to create_limits_config(u)
       end
+    end
+
+    it 'deletes redundant mapreduce limits' do
+      expect(chef_run).to delete_limits_config('mapreduce')
     end
 
     it 'runs execute[update hadoop-conf alternatives]' do

--- a/spec/hbase_spec.rb
+++ b/spec/hbase_spec.rb
@@ -55,6 +55,10 @@ describe 'hadoop::hbase' do
       expect(chef_run).to create_template('/etc/hbase/conf.chef/hbase-env.sh')
     end
 
+    it 'sets hbase limits' do
+      expect(chef_run).to create_limits_config('hbase')
+    end
+
     it 'runs execute[update hbase-conf alternatives]' do
       expect(chef_run).to run_execute('update hbase-conf alternatives')
     end


### PR DESCRIPTION
Set limits for hdfs/mapred/yarn and hbase, as set by CDH and HDP prior to 2.2... This brings HDP 2.2 in line with the rest of the distributions.