### PR TITLE
COOK-37 Setting limits aren't honored on Ubuntu via 'su'

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,7 @@ group :integration do
   cookbook 'java', '~> 1.21'
 end
 
+# This is here until bmhatfield/chef-ulimit#41 is merged and a new version of the cookbook is released
+cookbook 'ulimit', github: 'wolf31o2/ulimit_cookbook', ref: 'feature/matchers'
+
 metadata

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     "yum": ">= 3.0",
     "apt": ">= 0.0.0",
     "sysctl": ">= 0.0.0",
-    "limits": ">= 0.0.0"
+    "ulimit": ">= 0.0.0"
   },
   "recommendations": {
     "java": "~> 1.21"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version          '1.13.1'
 depends 'yum', '>= 3.0'
 depends 'apt'
 depends 'sysctl'
-depends 'limits'
+depends 'ulimit'
 
 recommends 'java', '~> 1.21'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -227,20 +227,22 @@ end
 # limits.d settings
 if node['hadoop'].key?('limits') && !node['hadoop']['limits'].empty?
   %w(hdfs mapred yarn).each do |u|
-    l = []
-    node['hadoop']['limits'].each do |k, v|
-      l << { domain: u, type: '-', item: k, value: v }
+    ulimit_domain u do
+      node['hadoop']['limits'].each do |k, v|
+        rule do
+          item k
+          type '-'
+          value v
+        end
+      end
     end
-
-    limits_config u do
-      action :create
-      limits l
-    end
-  end
-  limits_config 'mapreduce' do
-    action :delete
   end
 end # End limits.d
+
+# Remove extra mapreduce file, if it exists
+file '/etc/security/limits.d/mapreduce.conf' do
+  action :delete
+end
 
 # Update alternatives to point to our configuration
 execute 'update hadoop-conf alternatives' do

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -137,14 +137,15 @@ if node['hbase'].key?('jaas')
 end # End jaas.conf
 
 # limits.d settings
-if node['hbase'].key?('limits') && !node['hbase']['limits'].empty?
-  l = []
+ulimit_domain 'hbase' do
   node['hbase']['limits'].each do |k, v|
-    l << { domain: 'hbase', type: '-', item: k, value: v }
+    rule do
+      item k
+      type '-'
+      value v
+    end
   end
-  limits_config 'hbase' do
-    limits l
-  end
+  only_if { node['hbase'].key?('limits') && !node['hbase']['limits'].empty? }
 end # End limits.d
 
 # Update alternatives to point to our configuration

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -127,12 +127,12 @@ describe 'hadoop::default' do
 
     it 'sets limits for hdfs/mapred/yarn' do
       %w(hdfs mapred yarn).each do |u|
-        expect(chef_run).to create_limits_config(u)
+        expect(chef_run).to create_ulimit_domain(u)
       end
     end
 
     it 'deletes redundant mapreduce limits' do
-      expect(chef_run).to delete_limits_config('mapreduce')
+      expect(chef_run).to delete_file('/etc/security/limits.d/mapreduce.conf')
     end
 
     it 'runs execute[update hadoop-conf alternatives]' do

--- a/spec/hbase_spec.rb
+++ b/spec/hbase_spec.rb
@@ -56,7 +56,7 @@ describe 'hadoop::hbase' do
     end
 
     it 'sets hbase limits' do
-      expect(chef_run).to create_limits_config('hbase')
+      expect(chef_run).to create_ulimit_domain('hbase')
     end
 
     it 'runs execute[update hbase-conf alternatives]' do


### PR DESCRIPTION
- Switch to ulimits cookbook
- Use my ulimits fork until bmhatfield/chef-ulimit#41 is merged

Now, this will setup Ubuntu to respect limits via 'su' which is how most Hadoop services are started