### PR TITLE
Put out a deprecation notice for shortened distribution_version

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -33,7 +33,7 @@ node.default['hadoop']['distribution_version'] =
   if node['hadoop']['distribution'] == 'hdp'
     '2.1.7.0'
   elsif node['hadoop']['distribution'] == 'cdh'
-    '5'
+    '5.3.2'
   elsif node['hadoop']['distribution'] == 'bigtop'
     '0.8.0'
   end
@@ -161,6 +161,7 @@ when 'cdh'
   if node['hadoop']['distribution_version'].to_f >= 5.3 && node.key?('java') && node['java'].key?('jdk_version') && node['java']['jdk_version'] < 7
     Chef::Application.fatal!('CDH 5.3 and above require Java 7 or higher')
   end
+  Chef::Log.warn("Short versions for node['hadoop']['distribution_version'] are deprecated! Please use full version!") if node['hadoop']['distribution_version'].to_s == '5'
   case node['platform_family']
   when 'rhel'
     yum_base_url = "http://archive.cloudera.com/cdh#{cdh_release}/redhat"

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -31,7 +31,7 @@ end
 # Set defaults for version, based on distribution
 node.default['hadoop']['distribution_version'] =
   if node['hadoop']['distribution'] == 'hdp'
-    '2.1'
+    '2.1.7.0'
   elsif node['hadoop']['distribution'] == 'cdh'
     '5'
   elsif node['hadoop']['distribution'] == 'bigtop'
@@ -47,6 +47,8 @@ when 'hdp'
   when '2.0'
     hdp_version = '2.0.4.0'
     hdp_update_version = '2.0.13.0'
+    Chef::Log.warn("Short versions for node['hadoop']['distribution_version'] are deprecated! Please use full version!")
+    node.override['hadoop']['distribution_version'] = hdp_update_version
   when '2.0.4.0', '2.1.1.0', '2.2.0.0'
     hdp_version = node['hadoop']['distribution_version']
     hdp_update_version = nil
@@ -56,9 +58,14 @@ when 'hdp'
   when '2.1'
     hdp_version = '2.1.1.0'
     hdp_update_version = '2.1.7.0'
-  when '2.2.4.2', '2.2', '2'
+  when '2.2.4.2'
     hdp_version = '2.2.0.0'
     hdp_update_version = '2.2.4.2'
+  when '2.2', '2'
+    hdp_version = '2.2.0.0'
+    hdp_update_version = '2.2.4.2'
+    Chef::Log.warn("Short versions for node['hadoop']['distribution_version'] are deprecated! Please use full version!")
+    node.override['hadoop']['distribution_version'] = hdp_update_version
   else
     Chef::Application.fatal!('This cookbook only supports HDP 2.x')
   end

--- a/spec/avro_spec.rb
+++ b/spec/avro_spec.rb
@@ -17,7 +17,7 @@ describe 'hadoop::avro' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = 5
+        node.override['hadoop']['distribution_version'] = '5.3.2'
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end

--- a/spec/hadoop_yarn_nodemanager_spec.rb
+++ b/spec/hadoop_yarn_nodemanager_spec.rb
@@ -41,7 +41,7 @@ describe 'hadoop::hadoop_yarn_nodemanager' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.2'
+        node.override['hadoop']['distribution_version'] = '2.2.4.2'
         node.automatic['domain'] = 'example.com'
         stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)

--- a/spec/hive_spec.rb
+++ b/spec/hive_spec.rb
@@ -75,7 +75,7 @@ describe 'hadoop::hive' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.2'
+        node.override['hadoop']['distribution_version'] = '2.2.4.2'
         node.automatic['domain'] = 'example.com'
         node.default['hive']['hive_site']['hive.exec.local.scratchdir'] = '/tmp/hive/scratch'
         node.default['hive']['hive_env']['hive_log_dir'] = '/data/log/hive'

--- a/spec/parquet_spec.rb
+++ b/spec/parquet_spec.rb
@@ -17,7 +17,7 @@ describe 'hadoop::parquet' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = 5
+        node.override['hadoop']['distribution_version'] = '5.3.2'
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end

--- a/spec/spark_historyserver_spec.rb
+++ b/spec/spark_historyserver_spec.rb
@@ -39,7 +39,7 @@ describe 'hadoop::spark_historyserver' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = 5
+        node.override['hadoop']['distribution_version'] = '5.3.2'
         stub_command('test -L /var/log/spark').and_return(false)
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
       end.converge(described_recipe)

--- a/spec/spark_master_spec.rb
+++ b/spec/spark_master_spec.rb
@@ -22,7 +22,7 @@ describe 'hadoop::spark_master' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = 5
+        node.override['hadoop']['distribution_version'] = '5.3.2'
         stub_command('test -L /var/log/spark').and_return(false)
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)

--- a/spec/spark_spec.rb
+++ b/spec/spark_spec.rb
@@ -62,7 +62,7 @@ describe 'hadoop::spark' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = 5
+        node.override['hadoop']['distribution_version'] = '5.3.2'
         stub_command('test -L /var/log/spark').and_return(false)
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
       end.converge(described_recipe)

--- a/spec/spark_worker_spec.rb
+++ b/spec/spark_worker_spec.rb
@@ -27,7 +27,7 @@ describe 'hadoop::spark_worker' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = 5
+        node.override['hadoop']['distribution_version'] = '5.3.2'
         stub_command('test -L /var/log/spark').and_return(false)
         stub_command('update-alternatives --display spark-conf | grep best | awk \'{print $5}\' | grep /etc/spark/conf.chef').and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)


### PR DESCRIPTION
This is in preparation for the next major release of this cookbook, which will remove support for the shortened versions.