### PR TITLE
transparent-hugepage - correct exit status when file is missing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2013-2014 Cask Data, Inc.
+Copyright (c) 2013-2014 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2014 Cask Data, Inc.
+Copyright © 2013-2014 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -33,14 +33,18 @@ end
 # Do not assume file exists, Ubuntu 14 in AWS does not have thp_defrag file
 update_thp_defrag = true
 if ::File.exist?(thp_defrag)
-  file = File.new("#{thp_defrag}")
+  file = File.new(thp_defrag)
   text = file.read
-  if text =~ /\[never\]/
-    update_thp_defrag = false
-  end
+  update_thp_defrag = false if text =~ /\[never\]/
 else
   update_thp_defrag = false
 end
+
+# Do not assume file exists, Ubuntu 14 in AWS does not have thp_defrag file
+update_thp_defrag = true
+file = File.new(thp_defrag)
+text = file.read
+update_thp_defrag = false if ::File.exist?(thp_defrag) && text =~ /\[never\]/
 
 execute 'disable-transparent-hugepage-compaction' do
   command "echo never > #{thp_defrag}"

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -43,4 +43,5 @@ end
 execute 'disable-transparent-hugepage-compaction' do
   command "echo never > #{thp_defrag}"
   only_if { update_thp_defrag }
+  action :run
 end

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -40,12 +40,6 @@ else
   update_thp_defrag = false
 end
 
-# Do not assume file exists, Ubuntu 14 in AWS does not have thp_defrag file
-update_thp_defrag = true
-file = File.new(thp_defrag)
-text = file.read
-update_thp_defrag = false if ::File.exist?(thp_defrag) && text =~ /\[never\]/
-
 execute 'disable-transparent-hugepage-compaction' do
   command "echo never > #{thp_defrag}"
   only_if { update_thp_defrag }

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -33,6 +33,6 @@ end
 
 # disable transparent_hugepage (if exists, file missing on AWS Ubuntu images)
 execute 'disable-transparent-hugepage-compaction' do
-  command "ls #{thp_defrag} && echo never > #{thp_defrag}"
-  not_if "ls #{thp_defrag} && grep '\[never\]' #{thp_defrag}"
+  command "(ls #{thp_defrag} && echo never #{thp_defrag}) || (ls #{thp_defrag} || exit 0)"
+  not_if "(ls #{thp_defrag} && grep '\[never\]' #{thp_defrag}) || (ls #{thp_defrag} || exit 0)"
 end

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -23,6 +23,7 @@ sysctl_param 'vm.swappiness' do
   value 0
 end
 
+# select transparent_hugepage file
 case node['platform_family']
 when 'debian', 'suse'
   thp_defrag = '/sys/kernel/mm/transparent_hugepage/defrag'
@@ -30,7 +31,8 @@ when 'rhel'
   thp_defrag = '/sys/kernel/mm/redhat_transparent_hugepage/defrag'
 end
 
+# disable transparent_hugepage (if exists, file missing on AWS Ubuntu images)
 execute 'disable-transparent-hugepage-compaction' do
-  command "echo never > #{thp_defrag}"
-  not_if "ls #{thp_defrag} && grep '\[never\]' #{thp_defrag}"
+  command "(ls #{thp_defrag} && echo never #{thp_defrag}) || (ls #{thp_defrag} || exit 0)"
+  not_if "(ls #{thp_defrag} && grep '\[never\]' #{thp_defrag}) || (ls #{thp_defrag} || exit 0)"
 end

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -33,6 +33,6 @@ end
 
 # disable transparent_hugepage (if exists, file missing on AWS Ubuntu images)
 execute 'disable-transparent-hugepage-compaction' do
-  command "echo never > #{thp_defrag}"
+  command "ls #{thp_defrag} && echo never > #{thp_defrag}"
   not_if "ls #{thp_defrag} && grep '\[never\]' #{thp_defrag}"
 end

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 #
 
-include_recipe 'sysctl::default'
+#include_recipe 'sysctl::default'
 # Disable swapping
-sysctl_param 'vm.swappiness' do
-  value 0
-end
+#sysctl_param 'vm.swappiness' do
+#  value 0
+#end
 
 case node['platform_family']
 when 'debian', 'suse'
@@ -32,15 +32,13 @@ end
 
 # Do not assume file exists, Ubuntu 14 in AWS does not have thp_defrag file
 update_thp_defrag = true
-if ::File.exists?(thp_defrag) then
+if ::File.exist?(thp_defrag)
   file = File.new("#{thp_defrag}")
   text = file.read
-  if ( text =~ /\[never\]/ ) then
-    #puts "#{thp_defrag} contains [never]"
+  if text =~ /\[never\]/
     update_thp_defrag = false
   end
 else
-  #puts "file #{thp_defrag} not found"
   update_thp_defrag = false
 end
 


### PR DESCRIPTION
The previous patch resolves trying to write to file if not there, however, the ls (check) throws exit 2.  This version will correctly return exit 0 if file does not exist,,, and still properly handle it when the file does exist.

the transparent-hugepage file does not exist on AWS Ubuntu precise and trusty images.