### PR TITLE
[hive] fix pkg name of mysql-connector-java(src) to libmysql-java(bin)

### DIFF
--- a/recipes/hive.rb
+++ b/recipes/hive.rb
@@ -38,7 +38,7 @@ java_share_dir = '/usr/share/java'
 case node['platform_family']
 when 'debian'
   pkgs = %w(
-    mysql-connector-java
+    libmysql-java
     libpostgresql-jdbc-java
   )
   jars = %w(


### PR DESCRIPTION
fix pkg name of mysql-connector-java(src) to libmysql-java(bin)

On both debian and ubuntu (checked both precise and trusty) the binary pkg name is libmysql-java, for source pkg name of mysql-connector-java

This change was required to deploy on normal distribution of precise.