### PR TITLE
COOK-44 Move compression libs to helper recipe

### DIFF
--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -1,0 +1,46 @@
+#
+# Cookbook Name:: hadoop
+# Recipe:: _compression_libs
+#
+# Copyright © 2013-2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'hadoop::repo'
+
+pkgs = []
+
+# Everybody gets snappy
+case node['platform_family']
+when 'debian'
+  pkgs += ['libsnappy1', 'libsnappy1-dev']
+when 'rhel'
+  pkgs += ['snappy', 'snappy-devel']
+end
+
+# HDP has lzo
+if node['hadoop']['distribution'] == 'hdp'
+  case node['platform_family']
+  when 'debian'
+    pkgs += ['liblzo2-2', 'liblzo2-dev', 'hadooplzo']
+  when 'rhel'
+    pkgs += ['lzo', 'lzo-devel', 'hadooplzo', 'hadooplzo-native']
+  end
+end
+
+pkgs.each do |pkg|
+  package pkg do
+    action :install
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::_hadoop_checkconfig'
+include_recipe 'hadoop::_compression_libs'
 
 package 'hadoop-client' do
   action :install

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -19,21 +19,9 @@
 
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::zookeeper'
+include_recipe 'hadoop::_compression_libs'
 
 package 'hbase' do
-  action :install
-end
-
-# HBase needs snappy
-pkg =
-  case node['platform_family']
-  when 'debian'
-    'libsnappy1'
-  when 'rhel'
-    'snappy'
-  end
-
-package pkg do
   action :install
 end
 

--- a/spec/_compression_libs_spec.rb
+++ b/spec/_compression_libs_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe 'hadoop::_compression_libs' do
+  context 'on Centos 6.6' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
+    end
+
+    %w(snappy snappy-devel lzo lzo-devel hadooplzo hadooplzo-native).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+  end
+
+  context 'using CDH' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.override['hadoop']['distribution'] = 'cdh'
+        node.override['hadoop']['distribution_version'] = '5.4.1'
+      end.converge(described_recipe)
+    end
+
+    %w(snappy snappy-devel).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+
+    %w(lzo lzo-devel hadooplzo hadooplzo-native).each do |pkg|
+      it "does not install #{pkg} package" do
+        expect(chef_run).not_to install_package(pkg)
+      end
+    end
+  end
+
+  context 'on Ubuntu 12.04' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
+    end
+
+    %w(libsnappy1 libsnappy1-dev liblzo2-2 liblzo2-dev hadooplzo).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+  end
+
+  context 'using CDH' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
+        node.override['hadoop']['distribution'] = 'cdh'
+        node.override['hadoop']['distribution_version'] = '5.4.1'
+      end.converge(described_recipe)
+    end
+
+    %w(libsnappy1 libsnappy1-dev).each do |pkg|
+      it "installs #{pkg} package" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+
+    %w(liblzo2-2 liblzo2-dev hadooplzo).each do |pkg|
+      it "does not install #{pkg} package" do
+        expect(chef_run).not_to install_package(pkg)
+      end
+    end
+  end
+end

--- a/spec/hbase_spec.rb
+++ b/spec/hbase_spec.rb
@@ -19,10 +19,6 @@ describe 'hadoop::hbase' do
       expect(chef_run).to install_package('hbase')
     end
 
-    it 'installs snappy package' do
-      expect(chef_run).to install_package('snappy')
-    end
-
     it 'creates hbase conf_dir' do
       expect(chef_run).to create_directory('/etc/hbase/conf.chef').with(
         user: 'root',
@@ -65,20 +61,6 @@ describe 'hadoop::hbase' do
 
     it 'runs execute[update hbase-conf alternatives]' do
       expect(chef_run).to run_execute('update hbase-conf alternatives')
-    end
-  end
-
-  context 'on Ubuntu 12.04' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
-        node.automatic['domain'] = 'example.com'
-        node.default['hadoop']['hdfs_site']['dfs.datanode.max.xcievers'] = '4096'
-        stub_command(/update-alternatives --display /).and_return(false)
-      end.converge(described_recipe)
-    end
-
-    it 'installs libsnappy1 package' do
-      expect(chef_run).to install_package('libsnappy1')
     end
   end
 end


### PR DESCRIPTION
HDP ships LZO, so create a common recipe for compression libraries which aren't actually a part of Hadoop.