### PR TITLE
Fix package name

### DIFF
--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -24,7 +24,7 @@ pkgs = []
 # Everybody gets snappy
 case node['platform_family']
 when 'debian'
-  pkgs += ['libsnappy1', 'libsnappy1-dev']
+  pkgs += ['libsnappy1', 'libsnappy-dev']
 when 'rhel'
   pkgs += ['snappy', 'snappy-devel']
 end

--- a/spec/_compression_libs_spec.rb
+++ b/spec/_compression_libs_spec.rb
@@ -39,7 +39,7 @@ describe 'hadoop::_compression_libs' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    %w(libsnappy1 libsnappy1-dev liblzo2-2 liblzo2-dev hadooplzo).each do |pkg|
+    %w(libsnappy1 libsnappy-dev liblzo2-2 liblzo2-dev hadooplzo).each do |pkg|
       it "installs #{pkg} package" do
         expect(chef_run).to install_package(pkg)
       end
@@ -54,7 +54,7 @@ describe 'hadoop::_compression_libs' do
       end.converge(described_recipe)
     end
 
-    %w(libsnappy1 libsnappy1-dev).each do |pkg|
+    %w(libsnappy1 libsnappy-dev).each do |pkg|
       it "installs #{pkg} package" do
         expect(chef_run).to install_package(pkg)
       end


### PR DESCRIPTION
Package name is `libsnappy-dev` not `libsnappy1-dev` on Debian-based systems.