### PR TITLE
what looks like some minor typos

### DIFF
--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -24,7 +24,7 @@ pkgs = []
 # Everybody gets snappy
 case node['platform_family']
 when 'debian'
-  pkgs += ['libsnappy1', 'libsnappy1-dev']
+  pkgs += ['libsnappy1', 'libsnappy-dev']
 when 'rhel'
   pkgs += ['snappy', 'snappy-devel']
 end

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -63,7 +63,7 @@ end
 # Are we using automatic failover HA?
 if node['hadoop'].key?('hdfs_site') && node['hadoop']['hdfs_site'].key?('dfs.ha.automatic-failover.enabled') &&
    node['hadoop']['hdfs_site']['dfs.ha.automatic-failover.enabled'].to_s == 'true'
-  include_recipe 'hadoop::hadoop_hdfs_ha_checkconfig'
+  include_recipe 'hadoop::_hadoop_hdfs_ha_checkconfig'
   include_recipe 'hadoop::hadoop_hdfs_zkfc'
 end
 


### PR DESCRIPTION
the dev package at least on my ubuntu 14.04 box is libsnappy-dev without the '1'

also looks like the ha_checkconfig recipe may have been renamed.