### PR TITLE
Setup proper version-2 directories, so we can skip initialize

### DIFF
--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -84,8 +84,25 @@ directory zookeeper_data_dir do
   action :create
 end
 
+directory "#{zookeeper_data_dir}/version-2" do
+  owner 'zookeeper'
+  group 'hadoop'
+  mode '0755'
+  recursive true
+  action :create
+end
+
 unless zookeeper_datalog_dir == zookeeper_data_dir
   directory zookeeper_datalog_dir do
+    owner 'zookeeper'
+    group 'hadoop'
+    mode '0755'
+    recursive true
+    action :create
+    only_if { node['zookeeper']['zoocfg'].key?('dataLogDir') }
+  end
+
+  directory "#{zookeeper_datalog_dir}/version-2" do
     owner 'zookeeper'
     group 'hadoop'
     mode '0755'


### PR DESCRIPTION
The Cloudera init scripts ran `zookeeper-server-initialize` when called with `init`... This would run `/usr/lib/zookeeper/bin/zkServer-initialize.sh` which simply deletes/creates the `version-2` subdirectories for `dataDir` and `dataLogDir`, which are on the local file-system, so no need to execute it outside the cookbook.