### PR TITLE
Template-based init scripts (Part 3)

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -73,7 +73,7 @@ module Hadoop
     #
     # Return parent directory for various Hadoop lib directories and homes
     #
-    def lib_dir
+    def hadoop_lib_dir
       if hdp22?
         "/usr/hdp/#{hdp_version}"
       else

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -62,7 +62,7 @@ module Hadoop
     # Return true if Kerberos is enabled
     #
     # rubocop: disable Metrics/AbcSize
-    def kerberos?
+    def hadoop_kerberos?
       node['hadoop']['core_site'].key?('hadoop.security.authorization') &&
         node['hadoop']['core_site'].key?('hadoop.security.authentication') &&
         node['hadoop']['core_site']['hadoop.security.authorization'].to_s == 'true' &&

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -82,3 +82,7 @@ module Hadoop
     end
   end
 end
+
+# Load helpers
+Chef::Recipe.send(:include, Hadoop::Helpers)
+Chef::Resource.send(:include, Hadoop::Helpers)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -239,14 +239,14 @@ template '/etc/default/hadoop' do
   action :create
   variables :options => {
     'hadoop_home_warn_suppress' => true,
-    'hadoop_home' => "#{lib_dir}/hadoop",
-    'hadoop_prefix' => "#{lib_dir}/hadoop",
-    'hadoop_libexec_dir' => "#{lib_dir}/hadoop/libexec",
+    'hadoop_home' => "#{hadoop_lib_dir}/hadoop",
+    'hadoop_prefix' => "#{hadoop_lib_dir}/hadoop",
+    'hadoop_libexec_dir' => "#{hadoop_lib_dir}/hadoop/libexec",
     'hadoop_conf_dir' => '/etc/hadoop/conf',
-    'hadoop_common_home' => "#{lib_dir}/hadoop",
-    'hadoop_hdfs_home' => "#{lib_dir}/hadoop-hdfs",
-    'hadoop_mapred_home' => "#{lib_dir}/hadoop-mapreduce",
-    'hadoop_yarn_home' => "#{lib_dir}/hadoop-yarn",
+    'hadoop_common_home' => "#{hadoop_lib_dir}/hadoop",
+    'hadoop_hdfs_home' => "#{hadoop_lib_dir}/hadoop-hdfs",
+    'hadoop_mapred_home' => "#{hadoop_lib_dir}/hadoop-mapreduce",
+    'hadoop_yarn_home' => "#{hadoop_lib_dir}/hadoop-yarn",
     'jsvc_home' => '/usr/lib/bigtop-utils'
   }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,11 +21,6 @@ include_recipe 'hadoop::repo'
 include_recipe 'hadoop::_hadoop_checkconfig'
 include_recipe 'hadoop::_compression_libs'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Link.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package 'hadoop-client' do
   action :install
 end

--- a/recipes/flume_agent.rb
+++ b/recipes/flume_agent.rb
@@ -34,7 +34,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -91,7 +91,7 @@ hadoop_pid_dir =
   end
 
 target_user =
-  if kerberos?
+  if hadoop_kerberos?
     'root'
   else
     'hdfs'

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -22,10 +22,6 @@ include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hadoop-hdfs-datanode'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -34,7 +30,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -130,10 +130,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop HDFS DataNode',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop/sbin/hadoop-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop/sbin/hadoop-daemon.sh",
     'args' => '--config /etc/hadoop/conf start datanode',
     'user' => target_user,
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${HADOOP_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HADOOP_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -107,10 +107,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop HDFS JournalNode',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop/sbin/hadoop-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop/sbin/hadoop-daemon.sh",
     'args' => '--config /etc/hadoop/conf start journalnode',
     'user' => 'hdfs',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${HADOOP_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HADOOP_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -32,7 +32,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -22,10 +22,6 @@ include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hadoop-hdfs-namenode'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -34,7 +30,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -141,10 +141,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop HDFS NameNode',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop/sbin/hadoop-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop/sbin/hadoop-daemon.sh",
     'args' => '--config /etc/hadoop/conf start namenode',
     'user' => 'hdfs',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${HADOOP_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HADOOP_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -30,7 +30,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -128,10 +128,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop HDFS SecondaryNameNode',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop/sbin/hadoop-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop/sbin/hadoop-daemon.sh",
     'args' => '--config /etc/hadoop/conf start secondarynamenode',
     'user' => 'hdfs',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${HADOOP_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HADOOP_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_hdfs_zkfc.rb
+++ b/recipes/hadoop_hdfs_zkfc.rb
@@ -30,7 +30,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_hdfs_zkfc.rb
+++ b/recipes/hadoop_hdfs_zkfc.rb
@@ -88,10 +88,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop HDFS ZooKeeper Failover Controller',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop/sbin/hadoop-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop/sbin/hadoop-daemon.sh",
     'args' => '--config /etc/hadoop/conf start zkfc',
     'user' => 'hdfs',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${HADOOP_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HADOOP_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_mapreduce_historyserver.rb
+++ b/recipes/hadoop_mapreduce_historyserver.rb
@@ -108,7 +108,7 @@ template "/etc/default/#{pkg}" do
     'hadoop_mapred_pid_dir' => hadoop_pid_dir,
     'hadoop_mapred_log_dir' => hadoop_log_dir,
     'hadoop_mapred_ident_string' => 'mapred',
-    'hadoop_mapred_home' => "#{lib_dir}/hadoop-mapreduce",
+    'hadoop_mapred_home' => "#{hadoop_lib_dir}/hadoop-mapreduce",
     'hadoop_log_dir' => hadoop_log_dir
   }
 end
@@ -123,10 +123,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop MapReduce JobHistory Server',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop-mapreduce/sbin/mr-jobhistory-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop-mapreduce/sbin/mr-jobhistory-daemon.sh",
     'args' => '--config /etc/hadoop/conf start historyserver',
     'user' => 'mapred',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${HADOOP_MAPRED_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HADOOP_MAPRED_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_mapreduce_historyserver.rb
+++ b/recipes/hadoop_mapreduce_historyserver.rb
@@ -20,10 +20,6 @@
 include_recipe 'hadoop::default'
 pkg = 'hadoop-mapreduce-historyserver'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -32,7 +28,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_mapreduce_jobtracker.rb
+++ b/recipes/hadoop_mapreduce_jobtracker.rb
@@ -55,7 +55,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_mapreduce_tasktracker.rb
+++ b/recipes/hadoop_mapreduce_tasktracker.rb
@@ -50,7 +50,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -111,10 +111,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop YARN NodeManager',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop-yarn/sbin/yarn-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop-yarn/sbin/yarn-daemon.sh",
     'args' => '--config /etc/hadoop/conf start nodemanager',
     'user' => 'yarn',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${YARN_PID_DIR}/#{pkg}.pid",
     'logfile' => "${YARN_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -21,10 +21,6 @@ include_recipe 'hadoop::default'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hadoop-yarn-nodemanager'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -33,7 +29,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -51,15 +51,7 @@ end
 end
 
 # Ensure permissions for secure Hadoop... this *should* be no-op
-container_executor_path =
-  if node['hadoop']['distribution'] == 'hdp' && (node['hadoop']['distribution_version'].to_s == '2' || \
-                                                 node['hadoop']['distribution_version'].to_f == 2.2)
-    '/usr/hdp/current/hadoop-yarn-nodemanager/bin'
-  else
-    '/usr/lib/hadoop-yarn/bin'
-  end
-
-file "#{container_executor_path}/container-executor" do
+file "#{hadoop_lib_dir}/hadoop-yarn/bin/container-executor" do
   owner 'root'
   group 'yarn'
   mode '6050'

--- a/recipes/hadoop_yarn_proxyserver.rb
+++ b/recipes/hadoop_yarn_proxyserver.rb
@@ -88,10 +88,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop YARN Proxy Server',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop-yarn/sbin/yarn-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop-yarn/sbin/yarn-daemon.sh",
     'args' => '--config /etc/hadoop/conf start proxyserver',
     'user' => 'yarn',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${YARN_PID_DIR}/#{pkg}.pid",
     'logfile' => "${YARN_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_yarn_proxyserver.rb
+++ b/recipes/hadoop_yarn_proxyserver.rb
@@ -26,10 +26,6 @@ else
 end
 pkg = 'hadoop-yarn-proxyserver'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -38,7 +34,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -21,11 +21,6 @@ include_recipe 'hadoop::default'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hadoop-yarn-resourcemanager'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Execute.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -34,7 +29,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -152,10 +152,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hadoop YARN ResourceManager',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hadoop-yarn/sbin/yarn-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hadoop-yarn/sbin/yarn-daemon.sh",
     'args' => '--config /etc/hadoop/conf start resourcemanager',
     'user' => 'yarn',
-    'home' => "#{lib_dir}/hadoop",
+    'home' => "#{hadoop_lib_dir}/hadoop",
     'pidfile' => "${YARN_PID_DIR}/#{pkg}.pid",
     'logfile' => "${YARN_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -92,7 +92,7 @@ dfs = node['hadoop']['core_site']['fs.defaultFS']
 execute 'hdp22-mapreduce-tarball' do
   command <<-EOS
   hdfs dfs -mkdir -p #{dfs}/hdp/apps/#{hdp_version}/mapreduce && \
-  hdfs dfs -put /usr/hdp/current/hadoop-client/mapreduce.tar.gz /hdp/apps/#{hdp_version}/mapreduce && \
+  hdfs dfs -put #{hadoop_lib_dir}/hadoop/mapreduce.tar.gz /hdp/apps/#{hdp_version}/mapreduce && \
   hdfs dfs -chown -R hdfs:hadoop /hdp && \
   hdfs dfs -chmod -R 555 /hdp/apps/#{hdp_version}/mapreduce && \
   hdfs dfs -chmod -R 444 /hdp/apps/#{hdp_version}/mapreduce/mapreduce.tar.gz

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -104,7 +104,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'hbase_home' => "#{lib_dir}/hbase",
+    'hbase_home' => "#{hadoop_lib_dir}/hbase",
     'hbase_pid_dir' => '/var/run/hbase',
     'hbase_log_dir' => hbase_log_dir,
     'hbase_ident_string' => 'hbase'
@@ -121,10 +121,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'HBase Master',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hbase/bin/hbase-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hbase/bin/hbase-daemon.sh",
     'args' => '--config /etc/hbase/conf start master',
     'user' => 'hbase',
-    'home' => "#{lib_dir}/hbase",
+    'home' => "#{hadoop_lib_dir}/hbase",
     'pidfile' => "${HBASE_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HBASE_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -22,10 +22,6 @@ include_recipe 'hadoop::_hbase_checkconfig'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hbase-master'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -34,7 +30,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -22,10 +22,6 @@ include_recipe 'hadoop::_hbase_checkconfig'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hbase-regionserver'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -34,7 +30,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -58,7 +58,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'hbase_home' => "#{lib_dir}/hbase",
+    'hbase_home' => "#{hadoop_lib_dir}/hbase",
     'hbase_pid_dir' => '/var/run/hbase',
     'hbase_log_dir' => hbase_log_dir,
     'hbase_ident_string' => 'hbase'
@@ -75,10 +75,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'HBase RegionServer',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hbase/bin/hbase-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hbase/bin/hbase-daemon.sh",
     'args' => '--config /etc/hbase/conf start regionserver',
     'user' => 'hbase',
-    'home' => "#{lib_dir}/hbase",
+    'home' => "#{hadoop_lib_dir}/hbase",
     'pidfile' => "${HBASE_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HBASE_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hbase_rest.rb
+++ b/recipes/hbase_rest.rb
@@ -56,7 +56,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'hbase_home' => "#{lib_dir}/hbase",
+    'hbase_home' => "#{hadoop_lib_dir}/hbase",
     'hbase_pid_dir' => '/var/run/hbase',
     'hbase_log_dir' => hbase_log_dir,
     'hbase_ident_string' => 'hbase'
@@ -73,10 +73,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'HBase REST Service',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hbase/bin/hbase-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hbase/bin/hbase-daemon.sh",
     'args' => '--config /etc/hbase/conf start rest',
     'user' => 'hbase',
-    'home' => "#{lib_dir}/hbase",
+    'home' => "#{hadoop_lib_dir}/hbase",
     'pidfile' => "${HBASE_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HBASE_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hbase_rest.rb
+++ b/recipes/hbase_rest.rb
@@ -20,10 +20,6 @@
 include_recipe 'hadoop::hbase'
 pkg = 'hbase-rest'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -32,7 +28,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hbase_thrift.rb
+++ b/recipes/hbase_thrift.rb
@@ -56,7 +56,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'hbase_home' => "#{lib_dir}/hbase",
+    'hbase_home' => "#{hadoop_lib_dir}/hbase",
     'hbase_pid_dir' => '/var/run/hbase',
     'hbase_log_dir' => hbase_log_dir,
     'hbase_ident_string' => 'hbase',
@@ -74,10 +74,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'HBase Thrift Interface',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hbase/bin/hbase-daemon.sh",
+    'binary' => "#{hadoop_lib_dir}/hbase/bin/hbase-daemon.sh",
     'args' => '--config /etc/hbase/conf start thrift',
     'user' => 'hbase',
-    'home' => "#{lib_dir}/hbase",
+    'home' => "#{hadoop_lib_dir}/hbase",
     'pidfile' => "${HBASE_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HBASE_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hbase_thrift.rb
+++ b/recipes/hbase_thrift.rb
@@ -20,10 +20,6 @@
 include_recipe 'hadoop::hbase'
 pkg = 'hbase-thrift'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -32,7 +28,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -123,7 +123,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'hive_home' => "#{lib_dir}/hive",
+    'hive_home' => "#{hadoop_lib_dir}/hive",
     'hive_pid_dir' => '/var/run/hive',
     'hive_log_dir' => hive_log_dir,
     'hive_ident_string' => 'hive'
@@ -140,10 +140,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hive MetaStore',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hive/bin/hive",
+    'binary' => "#{hadoop_lib_dir}/hive/bin/hive",
     'args' => '--config /etc/hive/conf --service metastore > ${LOG_FILE} & < /dev/null',
     'user' => 'hive',
-    'home' => "#{lib_dir}/hive",
+    'home' => "#{hadoop_lib_dir}/hive",
     'pidfile' => "${HIVE_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HIVE_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -21,10 +21,6 @@ include_recipe 'hadoop::hive'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hive-metastore'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -33,7 +29,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -37,14 +37,6 @@ ruby_block "package-#{pkg}" do
   end
 end
 
-hive_data_dir =
-  if node['hadoop']['distribution'] == 'hdp' && (node['hadoop']['distribution_version'].to_s == '2' || \
-                                                 node['hadoop']['distribution_version'].to_f == 2.2)
-    '/usr/hdp/current/hive-client/lib'
-  else
-    '/usr/lib/hive/lib'
-  end
-
 hive_sql =
   if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.option.ConnectionURL')
     node['hive']['hive_site']['javax.jdo.option.ConnectionURL'].split(':')[1]
@@ -59,7 +51,7 @@ java_share_dir = '/usr/share/java'
 jars = node['hadoop']['sql_jars']
 
 jars.each do |jar|
-  link "#{hive_data_dir}/#{jar}.jar" do
+  link "#{hadoop_lib_dir}/hive/lib/#{jar}.jar" do
     to "#{java_share_dir}/#{jar}.jar"
   end
 end

--- a/recipes/hive_server.rb
+++ b/recipes/hive_server.rb
@@ -57,7 +57,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'hive_home' => "#{lib_dir}/hive",
+    'hive_home' => "#{hadoop_lib_dir}/hive",
     'hive_pid_dir' => '/var/run/hive',
     'hive_log_dir' => hive_log_dir,
     'hive_ident_string' => 'hive'
@@ -74,10 +74,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hive Server',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hive/bin/hive",
+    'binary' => "#{hadoop_lib_dir}/hive/bin/hive",
     'args' => '--config /etc/hive/conf --service server',
     'user' => 'hive',
-    'home' => "#{lib_dir}/hive",
+    'home' => "#{hadoop_lib_dir}/hive",
     'pidfile' => "${HIVE_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HIVE_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hive_server.rb
+++ b/recipes/hive_server.rb
@@ -21,10 +21,6 @@ include_recipe 'hadoop::hive'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'hive-server'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -33,7 +29,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -80,7 +80,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'hive_home' => "#{lib_dir}/hive",
+    'hive_home' => "#{hadoop_lib_dir}/hive",
     'hive_pid_dir' => '/var/run/hive',
     'hive_log_dir' => hive_log_dir,
     'hive_ident_string' => 'hive'
@@ -97,10 +97,10 @@ template "/etc/init.d/#{pkg}" do
     'desc' => 'Hive Server2',
     'name' => pkg,
     'process' => 'java',
-    'binary' => "#{lib_dir}/hive/bin/hive",
+    'binary' => "#{hadoop_lib_dir}/hive/bin/hive",
     'args' => '--config /etc/hive/conf --service server2',
     'user' => 'hive',
-    'home' => "#{lib_dir}/hive",
+    'home' => "#{hadoop_lib_dir}/hive",
     'pidfile' => "${HIVE_PID_DIR}/#{pkg}.pid",
     'logfile' => "${HIVE_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -23,10 +23,6 @@ include_recipe 'hadoop::_system_tuning'
 include_recipe 'hadoop::zookeeper'
 pkg = 'hive-server2'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -35,7 +31,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -29,7 +29,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/spark.rb
+++ b/recipes/spark.rb
@@ -33,7 +33,7 @@ end
 
 package 'spark-python' do
   action :install
-  only_if { hdp22? }
+  only_if { (node['hadoop']['distribution'] == 'cdh' || hdp22?) && node['spark']['release']['install'].to_s == 'false' }
 end
 
 # Spark MLib requires this

--- a/recipes/spark.rb
+++ b/recipes/spark.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: spark
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,9 +19,21 @@
 
 include_recipe 'hadoop::repo' if node['spark']['release']['install'].to_s == 'false'
 
-package 'spark-core' do
+pkg =
+  if node['hadoop']['distribution'] == 'cdh'
+    'spark-core'
+  else
+    'spark'
+  end
+
+package pkg do
   action :install
-  only_if { node['hadoop']['distribution'] == 'cdh' && node['spark']['release']['install'].to_s == 'false' }
+  only_if { (node['hadoop']['distribution'] == 'cdh' || hdp22?) && node['spark']['release']['install'].to_s == 'false' }
+end
+
+package 'spark-python' do
+  action :install
+  only_if { hdp22? }
 end
 
 # Spark MLib requires this

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -62,17 +62,52 @@ execute 'hdfs-spark-eventlog-dir' do
   action :nothing
 end
 
-if node['hadoop']['distribution'] == 'cdh'
-  s_cmd = "service #{pkg}"
-else
-  s_cmd = 'true #' # Ends with # to make arguments a comment, versus part of command line
+spark_log_dir =
+  if node['spark'].key?('spark_env') && node['spark']['spark_env'].key?('spark_log_dir')
+    node['spark']['spark_env']['spark_log_dir']
+  else
+    '/var/log/spark'
+  end
+
+# Create /etc/default configuration
+template "/etc/default/#{pkg}" do
+  source 'generic-env.sh.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+  action :create
+  variables :options => {
+    'spark_home' => "#{hadoop_lib_dir}/hbase",
+    'spark_pid_dir' => '/var/run/spark',
+    'spark_log_dir' => spark_log_dir,
+    'spark_ident_string' => 'spark',
+    'spark_history_server_log_dir' => eventlog_dir,
+    'spark_history_opts' => '$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=${SPARK_HISTORY_SERVER_LOG_DIR}',
+    'spark_conf_dir' => '/etc/spark/conf'
+  }
 end
 
-service 'spark-history-server' do
-  status_command "#{s_cmd} status"
-  start_command "#{s_cmd} start"
-  stop_command "#{s_cmd} stop"
-  restart_command "#{s_cmd} restart"
+template "/etc/init.d/#{pkg}" do
+  source 'hadoop-init.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+  action :create
+  variables :options => {
+    'desc' => 'Spark History Server',
+    'name' => pkg,
+    'process' => 'java',
+    'binary' => "#{hadoop_lib_dir}/spark/bin/spark-class",
+    'args' => 'org.apache.spark.deploy.history.HistoryServer > ${LOG_FILE} < /dev/null &',
+    'user' => 'spark',
+    'home' => "#{hadoop_lib_dir}/spark",
+    'pidfile' => "${SPARK_PID_DIR}/#{pkg}.pid",
+    'logfile' => "${SPARK_LOG_DIR}/#{pkg}.log"
+  }
+end
+
+service pkg do
+  status_command "service #{pkg} status"
   supports [:restart => true, :reload => false, :status => true]
   action :nothing
 end

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -28,7 +28,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -21,7 +21,7 @@ include_recipe 'hadoop::spark'
 include_recipe 'hadoop::_system_tuning'
 pkg = 'spark-master'
 
-if node['hadoop']['distribution'] == 'cdh'
+if node['hadoop']['distribution'] == 'cdh' || hdp22?
 
   package pkg do
     action :nothing
@@ -38,10 +38,61 @@ if node['hadoop']['distribution'] == 'cdh'
       end
     end
   end
+end
 
-  service pkg do
-    status_command "service #{pkg} status"
-    supports [:restart => true, :reload => false, :status => true]
-    action :nothing
+spark_log_dir =
+  if node['spark'].key?('spark_env') && node['spark']['spark_env'].key?('spark_log_dir')
+    node['spark']['spark_env']['spark_log_dir']
+  else
+    '/var/log/spark'
   end
+
+eventlog_dir =
+  if node['spark']['spark_defaults'].key?('spark.eventLog.dir')
+    node['spark']['spark_defaults']['spark.eventLog.dir']
+  else
+    '/user/spark/applicationHistory'
+  end
+
+# Create /etc/default configuration
+template "/etc/default/#{pkg}" do
+  source 'generic-env.sh.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+  action :create
+  variables :options => {
+    'spark_home' => "#{hadoop_lib_dir}/hbase",
+    'spark_pid_dir' => '/var/run/spark',
+    'spark_log_dir' => spark_log_dir,
+    'spark_ident_string' => 'spark',
+    'spark_history_server_log_dir' => eventlog_dir,
+    'spark_history_opts' => '$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=${SPARK_HISTORY_SERVER_LOG_DIR}',
+    'spark_conf_dir' => '/etc/spark/conf'
+  }
+end
+
+template "/etc/init.d/#{pkg}" do
+  source 'hadoop-init.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+  action :create
+  variables :options => {
+    'desc' => 'Spark Master',
+    'name' => pkg,
+    'process' => 'java',
+    'binary' => "#{hadoop_lib_dir}/spark/bin/spark-class",
+    'args' => 'org.apache.spark.deploy.master.Master > ${LOG_FILE} < /dev/null &',
+    'user' => 'spark',
+    'home' => "#{hadoop_lib_dir}/spark",
+    'pidfile' => "${SPARK_PID_DIR}/#{pkg}.pid",
+    'logfile' => "${SPARK_LOG_DIR}/#{pkg}.log"
+  }
+end
+
+service pkg do
+  status_command "service #{pkg} status"
+  supports [:restart => true, :reload => false, :status => true]
+  action :nothing
 end

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -31,7 +31,6 @@ if node['hadoop']['distribution'] == 'cdh'
   ruby_block "package-#{pkg}" do
     block do
       begin
-        Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
         policy_rcd('disable') if node['platform_family'] == 'debian'
         resources("package[#{pkg}]").run_action(:install)
       ensure

--- a/recipes/spark_worker.rb
+++ b/recipes/spark_worker.rb
@@ -31,7 +31,6 @@ if node['hadoop']['distribution'] == 'cdh'
   ruby_block "package-#{pkg}" do
     block do
       begin
-        Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
         policy_rcd('disable') if node['platform_family'] == 'debian'
         resources("package[#{pkg}]").run_action(:install)
       ensure

--- a/recipes/tez.rb
+++ b/recipes/tez.rb
@@ -24,9 +24,6 @@ package 'tez' do
   only_if { node['hadoop']['distribution'] == 'hdp' }
 end
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-
 # Copy tez library into HDFS
 dfs = node['hadoop']['core_site']['fs.defaultFS']
 dest =

--- a/recipes/tez.rb
+++ b/recipes/tez.rb
@@ -37,9 +37,9 @@ dest =
   end
 src =
   if hdp22?
-    "#{lib_dir}/tez/lib/tez.tar.gz"
+    "#{hadoop_lib_dir}/tez/lib/tez.tar.gz"
   else
-    "#{lib_dir}/tez/*"
+    "#{hadoop_lib_dir}/tez/*"
   end
 execute 'tez-hdfs-appdir' do
   command <<-EOS
@@ -104,7 +104,7 @@ if node.recipe?('hadoop::hive') && node['hive']['hive_site']['hive.execution.eng
   execute 'hive-hdfs-appdir' do
     command <<-EOS
     hdfs dfs -mkdir -p #{dfs}/apps/hive/install && \
-    hdfs dfs -copyFromLocal #{lib_dir}/hive/lib/hive-exec-* #{dfs}/apps/hive/install/
+    hdfs dfs -copyFromLocal #{hadoop_lib_dir}/hive/lib/hive-exec-* #{dfs}/apps/hive/install/
     EOS
     timeout 300
     user 'hdfs'

--- a/recipes/tez.rb
+++ b/recipes/tez.rb
@@ -36,10 +36,10 @@ dest =
     "#{dfs}/apps/tez"
   end
 src =
-  if hdp_version.to_f >= 2.2
-    "/usr/hdp/#{hdp_version}/tez/lib/tez.tar.gz"
+  if hdp22?
+    "#{lib_dir}/tez/lib/tez.tar.gz"
   else
-    '/usr/lib/tez/*'
+    "#{lib_dir}/tez/*"
   end
 execute 'tez-hdfs-appdir' do
   command <<-EOS
@@ -104,7 +104,7 @@ if node.recipe?('hadoop::hive') && node['hive']['hive_site']['hive.execution.eng
   execute 'hive-hdfs-appdir' do
     command <<-EOS
     hdfs dfs -mkdir -p #{dfs}/apps/hive/install && \
-    hdfs dfs -copyFromLocal /usr/lib/hive/lib/hive-exec-* #{dfs}/apps/hive/install/
+    hdfs dfs -copyFromLocal #{lib_dir}/hive/lib/hive-exec-* #{dfs}/apps/hive/install/
     EOS
     timeout 300
     user 'hdfs'

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -206,7 +206,7 @@ template "/etc/default/#{pkg}" do
   group 'root'
   action :create
   variables :options => {
-    'zookeeper_home' => "#{lib_dir}/zookeeper",
+    'zookeeper_home' => "#{hadoop_lib_dir}/zookeeper",
     'zookeeper_pid_dir' => '/var/run/zookeeper',
     'zookeeper_log_dir' => zookeeper_log_dir
   }
@@ -225,7 +225,7 @@ template "/etc/init.d/#{pkg}" do
     'binary' => "/usr/bin/#{pkg}",
     'args' => 'start',
     'user' => 'zookeeper',
-    'home' => "#{lib_dir}/zookeeper",
+    'home' => "#{hadoop_lib_dir}/zookeeper",
     'pidfile' => "${ZOOKEEPER_PID_DIR}/#{pkg}.pid",
     'logfile' => "${ZOOKEEPER_LOG_DIR}/#{pkg}.log"
   }

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -21,10 +21,6 @@ include_recipe 'hadoop::repo'
 include_recipe 'hadoop::zookeeper'
 pkg = 'zookeeper-server'
 
-# Load helpers
-Chef::Recipe.send(:include, Hadoop::Helpers)
-Chef::Resource::Template.send(:include, Hadoop::Helpers)
-
 package pkg do
   action :nothing
 end
@@ -33,7 +29,6 @@ end
 ruby_block "package-#{pkg}" do
   block do
     begin
-      Chef::Resource::RubyBlock.send(:include, Hadoop::Helpers)
       policy_rcd('disable') if node['platform_family'] == 'debian'
       resources("package[#{pkg}]").run_action(:install)
     ensure

--- a/spec/hadoop_yarn_nodemanager_spec.rb
+++ b/spec/hadoop_yarn_nodemanager_spec.rb
@@ -59,8 +59,8 @@ describe 'hadoop::hadoop_yarn_nodemanager' do
       end.converge(described_recipe)
     end
 
-    it 'ensures /usr/hdp/current/hadoop-yarn-nodemanager/bin/container-executor has proper permissions' do
-      expect(chef_run).to create_file('/usr/hdp/current/hadoop-yarn-nodemanager/bin/container-executor').with(
+    it 'ensures /usr/hdp/2.2.4.2-2/hadoop-yarn/bin/container-executor has proper permissions' do
+      expect(chef_run).to create_file('/usr/hdp/2.2.4.2-2/hadoop-yarn/bin/container-executor').with(
         user: 'root',
         group: 'yarn',
         mode: '6050'

--- a/spec/hive_metastore_spec.rb
+++ b/spec/hive_metastore_spec.rb
@@ -64,7 +64,7 @@ describe 'hadoop::hive_metastore' do
     end
 
     it 'link mysql-connector-java.jar' do
-      link = chef_run.link('/usr/hdp/current/hive-client/lib/mysql-connector-java.jar')
+      link = chef_run.link('/usr/hdp/2.2.4.2-2/hive/lib/mysql-connector-java.jar')
       expect(link).to link_to('/usr/share/java/mysql-connector-java.jar')
     end
   end
@@ -107,7 +107,7 @@ describe 'hadoop::hive_metastore' do
     end
 
     it 'link postgresql-jdbc4.jar' do
-      link = chef_run.link('/usr/hdp/current/hive-client/lib/postgresql-jdbc4.jar')
+      link = chef_run.link('/usr/hdp/2.2.4.2-2/hive/lib/postgresql-jdbc4.jar')
       expect(link).to link_to('/usr/share/java/postgresql-jdbc4.jar')
     end
   end

--- a/spec/spark_historyserver_spec.rb
+++ b/spec/spark_historyserver_spec.rb
@@ -10,10 +10,19 @@ describe 'hadoop::spark_historyserver' do
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)
     end
-    pkg = 'spark-historyserver'
+    pkg = 'spark-history-server'
 
     it "does not install #{pkg} package" do
       expect(chef_run).not_to install_package(pkg)
+    end
+
+    %W(
+      /etc/default/#{pkg}
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
     end
 
     it "creates #{pkg} service resource, but does not run it" do
@@ -52,6 +61,15 @@ describe 'hadoop::spark_historyserver' do
 
     it "runs package-#{pkg} ruby_block" do
       expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    %W(
+      /etc/default/#{pkg}
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
     end
 
     it "creates #{pkg} service resource, but does not run it" do

--- a/spec/spark_master_spec.rb
+++ b/spec/spark_master_spec.rb
@@ -11,6 +11,16 @@ describe 'hadoop::spark_master' do
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'spark-master'
+
+    %W(
+      /etc/default/#{pkg}
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
 
     it 'does not install spark-master package' do
       expect(chef_run).not_to install_package('spark-master')
@@ -36,6 +46,15 @@ describe 'hadoop::spark_master' do
 
     it "runs package-#{pkg} ruby_block" do
       expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    %W(
+      /etc/default/#{pkg}
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
     end
 
     it "creates #{pkg} service resource, but does not run it" do

--- a/spec/spark_spec.rb
+++ b/spec/spark_spec.rb
@@ -21,18 +21,18 @@ describe 'hadoop::spark' do
       expect(chef_run).to install_package('libgfortran')
     end
 
-    it 'creates Spark conf_dir' do
+    it 'creates spark conf_dir' do
       expect(chef_run).to create_directory('/etc/spark/conf.chef').with(
         user: 'root',
         group: 'root'
       )
     end
 
-    it 'deletes /var/log/spark' do
+    it 'deletes /var/log/spark directory' do
       expect(chef_run).to delete_directory('/var/log/spark')
     end
 
-    it 'creates /data/log/spark' do
+    it 'creates /data/log/spark directory' do
       expect(chef_run).to create_directory('/data/log/spark').with(
         mode: '0755'
       )

--- a/spec/spark_worker_spec.rb
+++ b/spec/spark_worker_spec.rb
@@ -12,6 +12,16 @@ describe 'hadoop::spark_worker' do
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'spark-worker'
+
+    %W(
+      /etc/default/#{pkg}
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
 
     it 'does not install spark-worker package' do
       expect(chef_run).not_to install_package('spark-worker')
@@ -41,6 +51,15 @@ describe 'hadoop::spark_worker' do
 
     it "runs package-#{pkg} ruby_block" do
       expect(chef_run).to run_ruby_block("package-#{pkg}")
+    end
+
+    %W(
+      /etc/default/#{pkg}
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
     end
 
     it "creates #{pkg} service resource, but does not run it" do

--- a/spec/zookeeper_server_spec.rb
+++ b/spec/zookeeper_server_spec.rb
@@ -23,6 +23,15 @@ describe 'hadoop::zookeeper_server' do
       expect(chef_run).to run_ruby_block("package-#{pkg}")
     end
 
+    %W(
+      /etc/default/#{pkg}
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
+
     it "creates #{pkg} service resource, but does not run it" do
       expect(chef_run).to_not disable_service(pkg)
       expect(chef_run).to_not enable_service(pkg)

--- a/templates/default/hadoop-init.erb
+++ b/templates/default/hadoop-init.erb
@@ -66,6 +66,10 @@ SYS_FILE="/etc/default/${NAME}"
 LOG_FILE="<%= @options['logfile'] %>"
 PKG_USER="<%= @options['user'] %>"
 PKG_HOME="<%= @options['home'] %>"
+CONF_DIR="<%= @options['confdir'] %>"
+
+[ -f ${CONF_DIR}/${NAME} ] && . ${CONF_DIR}/${NAME}
+
 EXE_FILE="<%= @options['binary'] %>"
 EXE_ARGS="<%= @options['args'] %>"
 PID_FILE="<%= @options['pidfile'] %>"

--- a/templates/default/hadoop-init.erb
+++ b/templates/default/hadoop-init.erb
@@ -68,7 +68,7 @@ PKG_USER="<%= @options['user'] %>"
 PKG_HOME="<%= @options['home'] %>"
 CONF_DIR="<%= @options['confdir'] %>"
 
-[ -f ${CONF_DIR}/${NAME} ] && . ${CONF_DIR}/${NAME}
+[ -f ${CONF_DIR}/${NAME}-env.sh ] && . ${CONF_DIR}/${NAME}-env.sh
 
 EXE_FILE="<%= @options['binary'] %>"
 EXE_ARGS="<%= @options['args'] %>"


### PR DESCRIPTION
This is the third part of the template-based init scripts, required for HDP 2.2, which includes some changes made in comments in #190 and #194.

- Prepend `kerberos?` and `lib_dir` with "hadoop_"
- Include `Hadoop::Helpers` in `Chef::Recipe` and `Chef::Resource`
- Spark support for HDP 2.2
- Spark client `spark-python` to `spark.rb`
- CONF_DIR variable in init script, and source `${CONF_DIR}/${NAME}-env.sh` if it exists