### PR TITLE
Removing guard from execute block with action :nothing

### DIFF
--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -67,7 +67,6 @@ execute 'yarn-app-mapreduce-am-staging-dir' do
   timeout 300
   user 'hdfs'
   group 'hdfs'
-  not_if "hdfs dfs -ls #{::File.dirname(am_staging_dir)} | grep #{am_staging_dir} | awk '{print $1,$3,$4}' | grep 'drwxrwxrwt yarn hadoop'", :user => 'hdfs'
   action :nothing
 end
 


### PR DESCRIPTION
This is fine, since "mkdir -p" and the "chmod" and "chown" commands are idempotent.