### PR TITLE
Supply /etc/default/hbase for hbase binary

### DIFF
--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -137,9 +137,20 @@ ulimit_domain 'hbase' do
   only_if { node['hbase'].key?('limits') && !node['hbase']['limits'].empty? }
 end # End limits.d
 
-# Remove extra hbase file, if it exists, since we do service-specific configs
-file '/etc/default/hbase' do
-  action :delete
+# Create /etc/default configuration
+template '/etc/default/hbase' do
+  source 'generic-env.sh.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+  action :create
+  variables :options => {
+    'hbase_home' => "#{hadoop_lib_dir}/hbase",
+    'hbase_pid_dir' => '/var/run/hbase',
+    'hbase_log_dir' => hbase_log_dir,
+    'hbase_ident_string' => 'hbase',
+    'hbase_conf_dir' => '/etc/hbase/conf'
+  }
 end
 
 # Another Hortonworks mess to clean up, their packages force-install blank configs here

--- a/spec/hbase_spec.rb
+++ b/spec/hbase_spec.rb
@@ -59,10 +59,6 @@ describe 'hadoop::hbase' do
       expect(chef_run).to create_ulimit_domain('hbase')
     end
 
-    it 'deletes /etc/default/hbase' do
-      expect(chef_run).to delete_file('/etc/default/hbase')
-    end
-
     it 'deletes /etc/hbase/conf directory' do
       expect(chef_run).to delete_directory('/etc/hbase/conf')
     end


### PR DESCRIPTION
The `hbase` binary on older HDP releases sources `/etc/default/hbase` unconditionally.