### PR TITLE
stub ruby call to retain thp chefspec tests

### DIFF
--- a/spec/_system_tuning_spec.rb
+++ b/spec/_system_tuning_spec.rb
@@ -4,6 +4,7 @@ describe 'hadoop::_system_tuning' do
   context 'on Centos 6.6' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do
+        allow(::File).to receive_messages(:file? => true)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
       end.converge(described_recipe)
     end
@@ -20,6 +21,7 @@ describe 'hadoop::_system_tuning' do
   context 'on Ubuntu 12.04' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do
+        allow(::File).to receive_messages(:file? => true)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
       end.converge(described_recipe)
     end


### PR DESCRIPTION
https://github.com/caskdata/hadoop_cookbook/pull/205 introduced failures in chefspec.  (not sure why travis didn't catch it).  This PR adds some rspec stubs to fix it.

```
Finished in 3 minutes 30.5 seconds (files took 3.51 seconds to load)
274 examples, 0 failures
```