### PR TITLE
Support latest patch levels for HDP and CDH

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,5 @@ SingleSpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
   Enabled: false
+Metrics/MethodLength:
+  Max: 15

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,12 +70,17 @@ end
 # MR settings for HDP 2.2+
 ###
 hdp_version =
-  if node['hadoop']['distribution_version'] == '2.2.0.0'
+  case node['hadoop']['distribution_version']
+  when '2.2.0.0'
     '2.2.0.0-2041'
-  elsif node['hadoop']['distribution_version'] == '2.2.1.0'
+  when '2.2.1.0'
     '2.2.1.0-2340'
-  elsif node['hadoop']['distribution_version'] == '2.2.4.2'
+  when '2.2.4.2'
     '2.2.4.2-2'
+  when '2.2.4.4'
+    '2.2.4.4-16'
+  when '2.2.6.0'
+    '2.2.6.0-2800'
   else
     node['hadoop']['distribution_version']
   end

--- a/attributes/tez.rb
+++ b/attributes/tez.rb
@@ -1,12 +1,17 @@
 default['tez']['tez_env']['tez_conf_dir'] = "/etc/tez/#{node['tez']['conf_dir']}"
 
 hdp_version =
-  if node['hadoop']['distribution_version'] == '2.2.0.0'
+  case node['hadoop']['distribution_version']
+  when '2.2.0.0'
     '2.2.0.0-2041'
-  elsif node['hadoop']['distribution_version'] == '2.2.1.0'
+  when '2.2.1.0'
     '2.2.1.0-2340'
-  elsif node['hadoop']['distribution_version'] == '2.2.4.2'
+  when '2.2.4.2'
     '2.2.4.2-2'
+  when '2.2.4.4'
+    '2.2.4.4-16'
+  when '2.2.6.0'
+    '2.2.6.0-2800'
   else
     node['hadoop']['distribution_version']
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,6 +46,10 @@ module Hadoop
         '2.2.1.0-2340'
       when '2.2.4.2'
         '2.2.4.2-2'
+      when '2.2.4.4'
+        '2.2.4.4-16'
+      when '2.2.6.0'
+        '2.2.6.0-2800'
       else
         node['hadoop']['distribution_version']
       end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -33,7 +33,7 @@ node.default['hadoop']['distribution_version'] =
   if node['hadoop']['distribution'] == 'hdp'
     '2.1.15.0'
   elsif node['hadoop']['distribution'] == 'cdh'
-    '5.3.4'
+    '5.3.5'
   elsif node['hadoop']['distribution'] == 'bigtop'
     '0.8.0'
   end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -52,18 +52,20 @@ when 'hdp'
   when '2.0.4.0', '2.1.1.0', '2.2.0.0'
     hdp_version = node['hadoop']['distribution_version']
     hdp_update_version = nil
-  when '2.1.2.0', '2.1.2.1', '2.1.3.0', '2.1.4.0', '2.1.5.0', '2.1.7.0', '2.1.10.0'
+  when '2.1.2.0', '2.1.2.1', '2.1.3.0', '2.1.4.0', '2.1.5.0', '2.1.7.0', '2.1.10.0', '2.1.15.0'
     hdp_version = '2.1.1.0'
     hdp_update_version = node['hadoop']['distribution_version']
   when '2.1'
     hdp_version = '2.1.1.0'
-    hdp_update_version = '2.1.7.0'
-  when '2.2.1.0', '2.2.4.2'
+    hdp_update_version = '2.1.15.0'
+    Chef::Log.warn("Short versions for node['hadoop']['distribution_version'] are deprecated! Please use full version!")
+    node.override['hadoop']['distribution_version'] = hdp_update_version
+  when '2.2.1.0', '2.2.4.2', '2.2.4.4', '2.2.6.0'
     hdp_version = '2.2.0.0'
     hdp_update_version = node['hadoop']['distribution_version']
   when '2.2', '2'
     hdp_version = '2.2.0.0'
-    hdp_update_version = '2.2.4.2'
+    hdp_update_version = '2.2.6.0'
     Chef::Log.warn("Short versions for node['hadoop']['distribution_version'] are deprecated! Please use full version!")
     node.override['hadoop']['distribution_version'] = hdp_update_version
   else

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -31,9 +31,9 @@ end
 # Set defaults for version, based on distribution
 node.default['hadoop']['distribution_version'] =
   if node['hadoop']['distribution'] == 'hdp'
-    '2.1.7.0'
+    '2.1.15.0'
   elsif node['hadoop']['distribution'] == 'cdh'
-    '5.3.2'
+    '5.3.4'
   elsif node['hadoop']['distribution'] == 'bigtop'
     '0.8.0'
   end


### PR DESCRIPTION
This ensures support for the latest versions of HDP and CDH and sets the defaults to the latest patch level for the distributions. Also, switches big `if...elsif...elsif...end` into a case.

- HDP
  - 2.2.4.4 and 2.2.6.0 for HDP 2.2
  - 2.1.15.0 for HDP 2.1 (default)
- CDH
  - 5.3.4 (default)