### PR TITLE
Feeling my way around a HA NN setup and populated dfs.nameservices but no…

### DIFF
--- a/recipes/_hadoop_hdfs_ha_checkconfig.rb
+++ b/recipes/_hadoop_hdfs_ha_checkconfig.rb
@@ -27,7 +27,7 @@ end
 # We have dfs.nameservices, and now need to check them
 dfs_nameservices.each do |ns|
   # Start namenode checks
-  Chef::Application.fatal!("Set dfs.ha.namenodes.nameservice")  unless node['hadoop']['hdfs_site'].key?("dfs\.ha\.namenodes\.#{ns}")
+  Chef::Application.fatal!("Set dfs.ha.namenodes.#{ns}")  unless node['hadoop']['hdfs_site'].key?("dfs\.ha\.namenodes\.#{ns}")
   # We need two and only two NameNodes
   namenodes = node['hadoop']['hdfs_site']["dfs\.ha\.namenodes\.#{ns}"].split(',')
   if namenodes.size != 2

--- a/recipes/_hadoop_hdfs_ha_checkconfig.rb
+++ b/recipes/_hadoop_hdfs_ha_checkconfig.rb
@@ -27,6 +27,9 @@ end
 # We have dfs.nameservices, and now need to check them
 dfs_nameservices.each do |ns|
   # Start namenode checks
+  if node['hadoop']['hdfs_site']['dfs.ha.namenodes'] 
+    Chef::Application.fatal!("NameNode HA requires node['hadoop']['hdfs_site']['dfs.ha.namenodes.#{ns}']") unless node['hadoop']['hdfs_site'].key?("dfs\.ha\.namenodes\.#{ns}")
+  end
   next unless node['hadoop']['hdfs_site'].key?("dfs\.ha\.namenodes\.#{ns}")
   # We need two and only two NameNodes
   namenodes = node['hadoop']['hdfs_site']["dfs\.ha\.namenodes\.#{ns}"].split(',')

--- a/recipes/_hadoop_hdfs_ha_checkconfig.rb
+++ b/recipes/_hadoop_hdfs_ha_checkconfig.rb
@@ -27,10 +27,7 @@ end
 # We have dfs.nameservices, and now need to check them
 dfs_nameservices.each do |ns|
   # Start namenode checks
-  if node['hadoop']['hdfs_site']['dfs.ha.namenodes'] 
-    Chef::Application.fatal!("NameNode HA requires node['hadoop']['hdfs_site']['dfs.ha.namenodes.#{ns}']") unless node['hadoop']['hdfs_site'].key?("dfs\.ha\.namenodes\.#{ns}")
-  end
-  next unless node['hadoop']['hdfs_site'].key?("dfs\.ha\.namenodes\.#{ns}")
+  Chef::Application.fatal!("Set dfs.ha.namenodes.nameservice")  unless node['hadoop']['hdfs_site'].key?("dfs\.ha\.namenodes\.#{ns}")
   # We need two and only two NameNodes
   namenodes = node['hadoop']['hdfs_site']["dfs\.ha\.namenodes\.#{ns}"].split(',')
   if namenodes.size != 2


### PR DESCRIPTION
…t the rest

default['hadoop']['hdfs_site']['dfs.nameservices']='kitchenCluster'
default['hadoop']['hdfs_site']['dfs.ha.namenodes']='kitchenCluster,kitchenCluster_TW0'

This PR checks the intention of doing HA by seeing dfs.ha.namenodes configured but not dfs.ha.namenodes.#{ns}.  Not sure if the unless should be removed or now.

default['hadoop']['hdfs_site']['dfs.ha.namenodes.kitchenCluster']='10.0.0.2,10.0.0.3'
default['hadoop']['hdfs_site']['dfs.namenode.rpc-address.kitchenCluster.10.0.0.2']='10.0.0.2:8020'
default['hadoop']['hdfs_site']['dfs.namenode.rpc-address.kitchenCluster.10.0.0.3']='10.0.0.3:8020'
default['hadoop']['hdfs_site']['dfs.namenode.http-address.kitchenCluster.10.0.0.2']='10.0.0.2:50070'
default['hadoop']['hdfs_site']['dfs.namenode.http-address.kitchenCluster.10.0.0.3']='10.0.0.3:50070'