### PR TITLE
wrong process name in hive-server2 init

### DIFF
--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -76,7 +76,7 @@ template "/etc/init.d/#{pkg}" do
     'name' => pkg,
     'process' => 'java',
     'binary' => "#{hadoop_lib_dir}/hive/bin/hive",
-    'args' => '--config ${CONF_DIR} --service server2 > ${LOG_FILE} 2>&1 < /dev/null & "\'echo $! \'"> ${PID_FILE}',
+    'args' => '--config ${CONF_DIR} --service hiveserver2 > ${LOG_FILE} 2>&1 < /dev/null & "\'echo $! \'"> ${PID_FILE}',
     'confdir' => '${HIVE_CONF_DIR}',
     'user' => 'hive',
     'home' => "#{hadoop_lib_dir}/hive",


### PR DESCRIPTION
init file uses the wrong name for the hiveserver2 executable causing the service start to fail