### PR TITLE
COOK-65 correct jar name for ubuntu

### DIFF
--- a/recipes/_sql_connectors.rb
+++ b/recipes/_sql_connectors.rb
@@ -32,11 +32,12 @@ if node['hadoop'].key?('sql_connector')
     else
       if node['platform_family'] == 'debian' && node['hadoop']['distribution'] != 'hdp'
         pkgs = ['libmysql-java']
+        jars = ['mysql-connector-java']
       else
         pkgs = ['mysql-connector-java']
+        jars = pkgs
       end
     end
-    jars = pkgs
   when 'postgresql'
     if node['platform_family'] == 'rhel'
       if node['platform_version'].to_i == '5'


### PR DESCRIPTION
fixes COOK-65

corrects the name of the installed mysql_connector jar on Ubuntu

```
dpkg -L libmysql-java | grep /usr/share/java.*.jar
/usr/share/java/mysql-connector-java-5.1.16.jar
/usr/share/java/mysql-connector-java.jar
/usr/share/java/mysql.jar
```