### PR TITLE
COOK-67 Set increment-allocation for Fair Scheduler (CDAP-2877)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,6 +48,11 @@ default['hadoop']['core_site']['fs.defaultFS'] = "hdfs://#{node['fqdn']}"
 # yarn-site.xml settings
 ###
 default['hadoop']['yarn_site']['yarn.resourcemanager.hostname'] = node['fqdn']
+default['hadoop']['yarn_site']['yarn.scheduler.increment-allocation-vcores'] = '1'
+
+# Ensure yarn.scheduler.minimum-allocation-mb >= yarn.scheduler.increment-allocation-mb
+default['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb'] = '1024'
+default['hadoop']['yarn_site']['yarn.scheduler.increment-allocation-mb'] = node['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb']
 
 # Set yarn.application.classpath
 if node['hadoop']['distribution'] == 'hdp' && node['hadoop']['distribution_version'].to_f >= 2.2

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,7 +52,12 @@ default['hadoop']['yarn_site']['yarn.scheduler.increment-allocation-vcores'] = '
 
 # Ensure yarn.scheduler.minimum-allocation-mb >= yarn.scheduler.increment-allocation-mb
 default['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb'] = '1024'
-default['hadoop']['yarn_site']['yarn.scheduler.increment-allocation-mb'] = node['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb']
+default['hadoop']['yarn_site']['yarn.scheduler.increment-allocation-mb'] =
+  if node['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb'].to_i < 1024
+    node['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb']
+  else
+    '1024'
+  end
 
 # Set yarn.application.classpath
 if node['hadoop']['distribution'] == 'hdp' && node['hadoop']['distribution_version'].to_f >= 2.2


### PR DESCRIPTION
Explicitly set increment for CPUs to 1, minimum for memory to 1024, and increment for memory to equal minimum.