### PR TITLE
Bumped apt cookbook dependency for 'trusted' apt_repository option to…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,8 +7,9 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.9'
 
 depends 'yum', '>= 3.0'
+depends 'apt', '>=2.1.2'
 
-%w(apt selinux sysctl ulimit).each do |cb|
+%w(selinux sysctl ulimit).each do |cb|
   depends cb
 end
 


### PR DESCRIPTION
apt_repository resource uses 'trusted' option that first appear in apt cookbook of version 2.1.2 (see changelog: https://github.com/chef-cookbooks/apt/blob/master/CHANGELOG.md).

Thus bump of apt dependency in metadata.rb.