### PR TITLE
Update Gemfile dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,15 @@ gem 'foodcritic', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
-gem 'chef', '< 12.0' if RUBY_VERSION.to_f < 2.0
+if RUBY_VERSION.to_f < 2.0
+  gem 'chef', '< 12.0'
+  gem 'varia_model', '< 0.5.0'
+else
+  gem 'chef', '< 12.5' # Testing
+end
+
+gem 'ridley', '~> 4.2.0'
+gem 'faraday', '< 0.9.2'
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'


### PR DESCRIPTION
Starting with varia_model 0.5.0, the minimum supported Ruby version
is >= 2.0, but we test on 1.9.3 as shipped with older Chef versions.

Constrain ridley and faraday to 4.2.0 and 0.9.1, respectively.

Rearrange constrains and use < Chef 12.5