### PR TITLE
Fix a syntax error in metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.1.0'
 
 depends 'yum', '>= 3.0'
-depends 'apt', '>=2.1.2'
+depends 'apt', '>= 2.1.2'
 
 %w(selinux sysctl ulimit).each do |cb|
   depends cb


### PR DESCRIPTION
Add a missing space to metadata.rb , otherwise I get this error installing via AWS OpsWorks

```
[2015-12-08T21:15:27+00:00] ERROR: Could not read /opt/aws/opsworks/current/merged-cookbooks/hadoop into a Chef object: The version constraint syntax you are using is not valid. If you recently
upgraded to Chef 0.10.0, be aware that you no may longer use "<<" and ">>" for
'less than' and 'greater than'; use '<' and '>' instead.
Consult http://wiki.opscode.com/display/chef/Metadata for more information.
 
Called by: depends 'apt', '>=2.1.2'
Called from:
/opt/aws/opsworks/releases/20151125145248_3430-20151125145248/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/cookbook/metadata.rb:519:in `validate_version_constraint'
/opt/aws/opsworks/releases/20151125145248_3430-20151125145248/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/cookbook/metadata.rb:262:in `depends'
/opt/aws/opsworks/current/merged-cookbooks/hadoop/metadata.rb:10:in `from_file'
/opt/aws/opsworks/releases/20151125145248_3430-20151125145248/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/mixin/from_file.rb:30:in `instance_eval'
/opt/aws/opsworks/releases/20151125145248_3430-20151125145248/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/mixin/from_file.rb:30:in `from_file'
 
[2015-12-08T21:15:27+00:00] ERROR: #<NoMethodError: undefined method `to_hash' for nil:NilClass>
```