### PR TITLE
Feature/bigtop new repos

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -181,31 +181,6 @@ suites:
       - recipe[hadoop::zookeeper]
       - recipe[hadoop::zookeeper_server]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2' } }
-  - name: bigtop080
-    excludes: debian-6.0.10, ubuntu-14.04
-    run_list:
-      - recipe[java::default]
-      - recipe[hadoop::default]
-      - recipe[hadoop::hadoop_hdfs_namenode]
-      - recipe[hadoop::hadoop_hdfs_secondarynamenode]
-      - recipe[hadoop::hadoop_hdfs_datanode]
-      - recipe[hadoop::hadoop_mapreduce_historyserver]
-      - recipe[hadoop::hadoop_yarn_resourcemanager]
-      - recipe[hadoop::hadoop_yarn_nodemanager]
-      - recipe[hadoop::hadoop_yarn_resourcemanager]
-      - recipe[hadoop::hbase_master]
-      - recipe[hadoop::hbase_regionserver]
-      - recipe[hadoop::hbase_rest]
-      - recipe[hadoop::hbase_thrift]
-      - recipe[hadoop::hive_metastore]
-      - recipe[hadoop::hive_server]
-      - recipe[hadoop::hive_server2]
-      - recipe[hadoop::oozie]
-      - recipe[hadoop::oozie_client]
-      - recipe[hadoop::pig]
-      - recipe[hadoop::zookeeper]
-      - recipe[hadoop::zookeeper_server]
-    attributes: { hadoop: { distribution: 'bigtop', distribution_version: '0.8.0' } }
   - name: bigtop100
     excludes: debian-6.0.10
     run_list:

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -234,12 +234,12 @@ when 'bigtop'
   bigtop_release = node['hadoop']['distribution_version']
 
   # allow a developer mode for use when developing against bigtop, see https://issues.cask.co/browse/COOK-1
-  if bigtop_release.casecmp('develop') && !(node['hadoop'].key?('yum_repo_url') || node['hadoop'].key?('apt_repo_url'))
+  if bigtop_release.casecmp('develop').zero? && !(node['hadoop'].key?('yum_repo_url') || node['hadoop'].key?('apt_repo_url'))
     Chef::Application.fatal!("You must set node['hadoop']['yum_repo_url'] or node['hadoop']['apt_repo_url'] when specifying node['hadoop']['distribution_version'] == 'develop'")
   end
 
   # do not validate gpg repo keys when in develop mode
-  validate_repo_key = bigtop_release.casecmp('develop') ? false : true
+  validate_repo_key = bigtop_release.casecmp('develop').zero? ? false : true
   Chef::Log.warn('Allowing install of unsigned binaries') unless validate_repo_key
 
   case node['platform_family']

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -35,7 +35,7 @@ node.default['hadoop']['distribution_version'] =
   elsif node['hadoop']['distribution'] == 'cdh'
     '5.3.5'
   elsif node['hadoop']['distribution'] == 'bigtop'
-    '0.8.0'
+    '1.0.0'
   end
 
 case node['hadoop']['distribution']
@@ -255,11 +255,7 @@ when 'bigtop'
       yum_platform_version = major_platform_version
     end
 
-    yum_base_url = if bigtop_release.to_f >= 1.0
-                     "http://bigtop.s3.amazonaws.com/releases/#{bigtop_release}/centos"
-                   else
-                     "http://bigtop.s3.amazonaws.com/releases/#{bigtop_release}/redhat"
-                   end
+    yum_base_url = "http://bigtop-repos.s3.amazonaws.com/releases/#{bigtop_release}/centos"
     yum_repo_url = node['hadoop']['yum_repo_url'] ? node['hadoop']['yum_repo_url'] : "#{yum_base_url}/#{yum_platform_version}/#{node['kernel']['machine']}"
     yum_repo_key_url = node['hadoop']['yum_repo_key_url'] ? node['hadoop']['yum_repo_key_url'] : 'http://archive.apache.org/dist/bigtop/KEYS'
 
@@ -286,7 +282,7 @@ when 'bigtop'
     end
     # rubocop: enable Metrics/BlockNesting
 
-    apt_domain_name = 'bigtop.s3.amazonaws.com'
+    apt_domain_name = 'bigtop-repos.s3.amazonaws.com'
     apt_base_url = "http://#{apt_domain_name}/releases/#{bigtop_release}/#{node['platform']}"
     apt_repo_url = node['hadoop']['apt_repo_url'] ? node['hadoop']['apt_repo_url'] : "#{apt_base_url}/#{codename}/#{node['kernel']['machine']}"
     apt_repo_key_url = node['hadoop']['apt_repo_key_url'] ? node['hadoop']['apt_repo_key_url'] : 'http://archive.apache.org/dist/bigtop/KEYS'


### PR DESCRIPTION
fixes https://issues.cask.co/browse/COOK-87 and restores bigtop support.

See [this thread](https://mail-archives.apache.org/mod_mbox/bigtop-dev/201510.mbox/%3CCAKGhRiskEHCYbJAGF41LKTHCnvPfYRHxNPdvBTN5FKj-Z10zag%40mail.gmail.com%3E) for more details but bigtop lost their S3 bucket.  ``0.8.0`` is no longer available, and ``1.0.0`` is available under a new repo url.

- [x] updates bigtop support accordingly
- [x] fixes an incorrect usage of ``.casecmp``