### PR TITLE
update Style/SpaceBeforeFirstArg

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ Documentation:
   Enabled: False
 HashSyntax:
   Enabled: False
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
   Enabled: false


### PR DESCRIPTION
fixes latest rubocop error causing travis failures:
```
Error: The `Style/SingleSpaceBeforeFirstArg` cop has been renamed to `Style/SpaceBeforeFirstArg. 
(obsolete configuration found in /Users/derek/git/public-cookbooks/hadoop/.rubocop.yml, please update it)
```