### PR TITLE
Create hadoop_package helper for ODP-based distributions

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -79,6 +79,21 @@ module Hadoop
     end
 
     #
+    # Return correct package name on ODP-based distributions
+    #
+    # Given name: hadoop-mapreduce-historyserver
+    # ODP name: hadoop_2_4_0_0_169-mapreduce-historyserver
+    #
+    def hadoop_package(name)
+      return name unless hdp22?
+      return name if node['platform_family'] == 'debian'
+      fw = name.split('-').first
+      pv = hdp_version.tr('.', '_').tr('-', '_')
+      nn = "#{fw}_#{pv}"
+      name.gsub(fw, nn)
+    end
+
+    #
     # Return true if Kerberos is enabled
     #
     # rubocop: disable Metrics/AbcSize

--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: _compression_libs
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ when 'rhel'
 end
 
 # HDP 2.2+ has lzo
-if node['hadoop']['distribution'] == 'hdp' && node['hadoop']['distribution_version'].to_f >= 2.2
+if hdp22?
   case node['platform_family']
   when 'debian'
     pkgs += ['liblzo2-2', 'liblzo2-dev', 'hadooplzo']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ include_recipe 'hadoop::repo'
 include_recipe 'hadoop::_hadoop_checkconfig'
 include_recipe 'hadoop::_compression_libs'
 
-package 'hadoop-client' do
+package hadoop_package('hadoop-client') do
   action :install
 end
 
@@ -29,7 +29,7 @@ libhdfs =
   if node['platform_family'] == 'debian'
     'libhdfs0'
   else
-    'hadoop-libhdfs'
+    hadoop_package('hadoop-libhdfs')
   end
 
 package libhdfs do

--- a/recipes/flume.rb
+++ b/recipes/flume.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: flume
 #
-# Copyright © 2013-2014 Continuuity, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ pkg =
   if node['hadoop']['distribution'] == 'cdh'
     'flume-ng'
   else
-    'flume'
+    hadoop_package('flume')
   end
 
 package pkg do

--- a/recipes/flume_agent.rb
+++ b/recipes/flume_agent.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: flume_agent
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ pkg =
   if node['hadoop']['distribution'] == 'cdh'
     'flume-ng-agent'
   else
-    'flume-agent'
+    hadoop_package('flume-agent')
   end
 
 package pkg do

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: hbase
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ include_recipe 'hadoop::repo'
 include_recipe 'hadoop::zookeeper'
 include_recipe 'hadoop::_compression_libs'
 
-package 'hbase' do
+package hadoop_package('hbase') do
   action :install
 end
 

--- a/recipes/hive.rb
+++ b/recipes/hive.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::repo'
 
-package 'hive' do
+package hadoop_package('hive') do
   action :install
 end
 

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::oozie_client'
-pkg = 'oozie'
+pkg = hadoop_package('oozie')
 
 package pkg do
   action :nothing

--- a/recipes/oozie_client.rb
+++ b/recipes/oozie_client.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: oozie_client
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,6 @@
 
 include_recipe 'hadoop::repo'
 
-package 'oozie-client' do
+package hadoop_package('oozie-client') do
   action :install
 end

--- a/recipes/pig.rb
+++ b/recipes/pig.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: pig
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,6 @@
 
 include_recipe 'hadoop::repo'
 
-package 'pig' do
+package hadoop_package('pig') do
   action :install
 end

--- a/recipes/spark.rb
+++ b/recipes/spark.rb
@@ -23,7 +23,7 @@ pkg =
   if node['hadoop']['distribution'] == 'cdh'
     'spark-core'
   else
-    'spark'
+    hadoop_package('spark')
   end
 
 package pkg do
@@ -31,7 +31,7 @@ package pkg do
   only_if { (node['hadoop']['distribution'] == 'cdh' || hdp22?) && node['spark']['release']['install'].to_s == 'false' }
 end
 
-package 'spark-python' do
+package hadoop_package('spark-python') do
   action :install
   only_if { (node['hadoop']['distribution'] == 'cdh' || hdp22?) && node['spark']['release']['install'].to_s == 'false' }
 end

--- a/recipes/storm.rb
+++ b/recipes/storm.rb
@@ -3,6 +3,7 @@
 # Recipe:: storm
 #
 # Copyright © 2015 VAHNA
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::_storm_checkconfig'
 
-package 'storm' do
+package hadoop_package('storm') do
   action :install
   only_if { hdp22? && node['storm']['release']['install'] == false }
   node.override['storm']['storm_env']['storm_home'] = "#{hadoop_lib_dir}/storm"
@@ -131,7 +132,7 @@ directory storm_log_dir do
   mode '0755'
   recursive true
   action :create
-  only_if { node['storm'].key?('storm_conf') && node['storm']['storm_conf'].key?('storm.log.dir') }
+  # only_if { node['storm'].key?('storm_conf') && node['storm']['storm_conf'].key?('storm.log.dir') }
 end
 
 unless storm_log_dir == "#{node['storm']['storm_env']['storm_home']}/logs"

--- a/recipes/tez.rb
+++ b/recipes/tez.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::repo' if node['hadoop']['distribution'] == 'hdp'
 
-package 'tez' do
+package hadoop_package('tez') do
   action :install
   only_if { node['hadoop']['distribution'] == 'hdp' }
 end

--- a/recipes/zookeeper.rb
+++ b/recipes/zookeeper.rb
@@ -20,7 +20,7 @@
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::_zookeeper_checkconfig'
 
-package 'zookeeper' do
+package hadoop_package('zookeeper') do
   action :install
 end
 

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::zookeeper'
-pkg = 'zookeeper-server'
+pkg = hadoop_package('zookeeper-server')
 
 # HDP 2.0.11.0 (maybe others) doesn't create zookeeper group
 group 'zookeeper' do

--- a/spec/storm_spec.rb
+++ b/spec/storm_spec.rb
@@ -6,7 +6,7 @@ describe 'hadoop::storm' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.0.0'
+        node.override['hadoop']['distribution_version'] = '2.4.0.0'
         node.default['storm']['release']['install'] = false
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
@@ -14,7 +14,7 @@ describe 'hadoop::storm' do
     end
 
     it 'installs storm package' do
-      expect(chef_run).to install_package('storm')
+      expect(chef_run).to install_package('storm_2_4_0_0_169')
     end
 
     it 'deletes /etc/storm/conf directory' do
@@ -30,11 +30,11 @@ describe 'hadoop::storm' do
     end
 
     it 'deletes rpm conf directory' do
-      expect(chef_run).to delete_directory(%r{/usr/hdp/2.3.0.0-.*/storm/conf})
+      expect(chef_run).to delete_directory(%r{/usr/hdp/2.4.0.0-.*/storm/conf})
     end
 
     it 'creates storm config symlink' do
-      link = chef_run.link(%r{/usr/hdp/2.3.0.0-.*/storm/conf})
+      link = chef_run.link(%r{/usr/hdp/2.4.0.0-.*/storm/conf})
       expect(link).to link_to('/etc/storm/conf.chef')
     end
 
@@ -55,7 +55,7 @@ describe 'hadoop::storm' do
     end
 
     it 'deletes rpm logs directory' do
-      expect(chef_run).to delete_directory(%r{/usr/hdp/2.3.0.0-.*/storm/logs})
+      expect(chef_run).to delete_directory(%r{/usr/hdp/2.4.0.0-.*/storm/logs})
     end
 
     it 'creates storm logs directory' do
@@ -67,7 +67,7 @@ describe 'hadoop::storm' do
     end
 
     it 'creates storm logs symlink' do
-      link = chef_run.link(%r{/usr/hdp/2.3.0.0-.*/storm/logs})
+      link = chef_run.link(%r{/usr/hdp/2.4.0.0-.*/storm/logs})
       expect(link).to link_to('/var/log/storm')
     end
 


### PR DESCRIPTION
Hortonworks packages use `provides` to provide short package names. However, other ODP-based distributions, such as IOP, do not. Instead, they use package names that include the distribution's version.

Example:
`hadoop-client` on HDP 2.4.0.0 becomes `hadoop_2_4_0_0_169-client`