### PR TITLE
Revert change to zookeeper_server recipe

### DIFF
--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::repo'
 include_recipe 'hadoop::zookeeper'
-pkg = hadoop_package('zookeeper-server')
+pkg = 'zookeeper-server'
 
 # HDP 2.0.11.0 (maybe others) doesn't create zookeeper group
 group 'zookeeper' do


### PR DESCRIPTION
This recipe doesn't actually do a package install, so it doesn't need to use `hadoop_package` helper. This reverses the change to this recipe done in #251 and makes the service name consistent, again.