### PR TITLE
COOK-93 Allow overriding distribution_version at default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ else
   gem 'chef', '< 12.5' # Testing
 end
 
+gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
+
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
 gem 'rubocop'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -25,7 +25,9 @@ include_recipe 'apt' if node['platform_family'] == 'debian'
 
 # Set defaults for version, based on distribution
 node.default['hadoop']['distribution_version'] =
-  if node['hadoop']['distribution'] == 'hdp'
+  if node['hadoop'].key?('distribution_version')
+    node['hadoop']['distribution_version']
+  elsif node['hadoop']['distribution'] == 'hdp'
     '2.3.4.7'
   elsif node['hadoop']['distribution'] == 'cdh'
     '5.6.0'

--- a/spec/_compression_libs_spec.rb
+++ b/spec/_compression_libs_spec.rb
@@ -5,7 +5,7 @@ describe 'hadoop::_compression_libs' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.override['hadoop']['distributon'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
       end.converge(described_recipe)
     end
 
@@ -19,8 +19,8 @@ describe 'hadoop::_compression_libs' do
   context 'using HDP 2.1.15.0' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.1.15.0'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.1.15.0'
       end.converge(described_recipe)
     end
 
@@ -60,8 +60,8 @@ describe 'hadoop::_compression_libs' do
   context 'on Ubuntu 12.04' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
       end.converge(described_recipe)
     end
 
@@ -75,8 +75,8 @@ describe 'hadoop::_compression_libs' do
   context 'using HDP 2.1.15.0' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.1.15.0'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.1.15.0'
       end.converge(described_recipe)
     end
 

--- a/spec/avro_spec.rb
+++ b/spec/avro_spec.rb
@@ -17,7 +17,7 @@ describe 'hadoop::avro' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = '5.3.2'
+        node.default['hadoop']['distribution_version'] = '5.3.2'
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -14,8 +14,8 @@ describe 'hadoop::default' do
         node.default['hadoop']['container_executor']['banned.users'] = 'root'
         node.default['hadoop']['hadoop_env']['hadoop_log_dir'] = '/data/log/hadoop-hdfs'
         node.default['hadoop']['yarn_env']['yarn_log_dir'] = '/var/log/hadoop-yarn'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
@@ -160,8 +160,8 @@ describe 'hadoop::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.1.15.0'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.1.15.0'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
@@ -182,8 +182,8 @@ describe 'hadoop::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.1.15.0'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.1.15.0'
         node.override['hadoop']['hadoop_env']['hadoop_log_dir'] = '/data/logs/hdfs'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(/test -L /).and_return(false)

--- a/spec/flume_agent_spec.rb
+++ b/spec/flume_agent_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::flume_agent' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
       end.converge(described_recipe)
     end
 

--- a/spec/flume_spec.rb
+++ b/spec/flume_spec.rb
@@ -6,8 +6,8 @@ describe 'hadoop::flume' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         node.default['flume']['flume_conf']['key'] = 'value'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
       end.converge(described_recipe)
     end
     conf_dir = '/etc/flume/conf.chef'

--- a/spec/hadoop_yarn_nodemanager_spec.rb
+++ b/spec/hadoop_yarn_nodemanager_spec.rb
@@ -4,8 +4,8 @@ describe 'hadoop::hadoop_yarn_nodemanager' do
   context 'on Centos 6.6' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.automatic['domain'] = 'example.com'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
@@ -25,8 +25,8 @@ describe 'hadoop::hadoop_yarn_nodemanager' do
   context 'using HDP 2.1.15.0' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.1.15.0'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.1.15.0'
         node.automatic['domain'] = 'example.com'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)

--- a/spec/hbase_spec.rb
+++ b/spec/hbase_spec.rb
@@ -10,8 +10,8 @@ describe 'hadoop::hbase' do
         node.default['hbase']['hbase_site']['hbase.rootdir'] = 'hdfs://localhost:8020/hbase'
         node.default['hbase']['hbase_env']['hbase_log_dir'] = '/data/log/hbase'
         node.default['hbase']['log4j']['log4j.threshold'] = 'ALL'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)

--- a/spec/hive_metastore_spec.rb
+++ b/spec/hive_metastore_spec.rb
@@ -44,8 +44,8 @@ describe 'hadoop::hive_metastore' do
   context 'using MySQL on HDP 2.3' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.override['hive']['hive_site']['javax.jdo.option.ConnectionURL'] = 'jdbc:mysql:localhost/hive'
         node.automatic['domain'] = 'example.com'
         node.default['hive']['hive_env']['hive_log_dir'] = '/data/log/hive'
@@ -65,8 +65,8 @@ describe 'hadoop::hive_metastore' do
   context 'using PostgreSQL on Ubuntu 12.04' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.override['hive']['hive_site']['javax.jdo.option.ConnectionURL'] = 'jdbc:postgresql:localhost/hive'
         node.automatic['domain'] = 'example.com'
         stub_command(/test -L /).and_return(false)
@@ -84,8 +84,8 @@ describe 'hadoop::hive_metastore' do
   context 'using PostgreSQL on Ubuntu 12.04 HDP 2.1.15.0' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.1.15.0'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.1.15.0'
         node.override['hive']['hive_site']['javax.jdo.option.ConnectionURL'] = 'jdbc:postgresql:localhost/hive'
         node.automatic['domain'] = 'example.com'
         stub_command(/test -L /).and_return(false)

--- a/spec/hive_spec.rb
+++ b/spec/hive_spec.rb
@@ -7,8 +7,8 @@ describe 'hadoop::hive' do
         node.automatic['domain'] = 'example.com'
         node.default['hive']['hive_site']['hive.exec.local.scratchdir'] = '/tmp/hive/scratch'
         node.default['hive']['hive_env']['hive_log_dir'] = '/data/log/hive'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)

--- a/spec/oozie_client_spec.rb
+++ b/spec/oozie_client_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::oozie_client' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
       end.converge(described_recipe)
     end
 

--- a/spec/oozie_spec.rb
+++ b/spec/oozie_spec.rb
@@ -7,8 +7,8 @@ describe 'hadoop::oozie' do
         node.automatic['domain'] = 'example.com'
         node.default['oozie']['oozie_env']['oozie_log_dir'] = '/data/log/oozie'
         node.default['oozie']['oozie_site']['example_property'] = 'test'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)

--- a/spec/parquet_spec.rb
+++ b/spec/parquet_spec.rb
@@ -17,7 +17,7 @@ describe 'hadoop::parquet' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = '5.3.2'
+        node.default['hadoop']['distribution_version'] = '5.3.2'
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end

--- a/spec/pig_spec.rb
+++ b/spec/pig_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::pig' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
       end.converge(described_recipe)
     end
 

--- a/spec/spark_spec.rb
+++ b/spec/spark_spec.rb
@@ -66,7 +66,7 @@ describe 'hadoop::spark' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = '5.3.2'
+        node.default['hadoop']['distribution_version'] = '5.3.2'
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)

--- a/spec/storm_nimbus_spec.rb
+++ b/spec/storm_nimbus_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::storm_nimbus' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.default['storm']['release']['install'] = false
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)

--- a/spec/storm_spec.rb
+++ b/spec/storm_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::storm' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.default['storm']['release']['install'] = false
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
@@ -85,7 +85,7 @@ describe 'hadoop::storm' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['hadoop']['distribution'] = 'cdh'
-        node.override['hadoop']['distribution_version'] = '5.3.2'
+        node.default['hadoop']['distribution_version'] = '5.3.2'
         node.override['storm']['release']['install'] = true
         node.override['storm']['release']['install_path'] = '/opt'
         node.override['storm']['release']['version'] = '0.9.5'

--- a/spec/storm_supervisor_spec.rb
+++ b/spec/storm_supervisor_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::storm_supervisor' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.default['storm']['release']['install'] = false
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)

--- a/spec/storm_ui_spec.rb
+++ b/spec/storm_ui_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::storm_ui' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.default['storm']['release']['install'] = false
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)

--- a/spec/tez_spec.rb
+++ b/spec/tez_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::tez' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         stub_command('hdfs dfs -test -d hdfs://fauxhai.local/apps/tez').and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)

--- a/spec/zookeeper_spec.rb
+++ b/spec/zookeeper_spec.rb
@@ -5,8 +5,8 @@ describe 'hadoop::zookeeper' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.override['hadoop']['distribution'] = 'hdp'
-        node.override['hadoop']['distribution_version'] = '2.3.4.7'
+        node.default['hadoop']['distribution'] = 'hdp'
+        node.default['hadoop']['distribution_version'] = '2.3.4.7'
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)
     end


### PR DESCRIPTION
This will keep any defined `node['hadoop']['distribution_version']` at the `default` precedence level. This fixes COOK-93