### PR TITLE
Set SPARK_DIST_CLASSPATH and redirect STDERR to logs

### DIFF
--- a/attributes/spark.rb
+++ b/attributes/spark.rb
@@ -17,9 +17,10 @@ default['spark']['spark_env']['spark_worker_webui_port']      = 18_081
 default['spark']['spark_env']['spark_master_port']            = 7077
 default['spark']['spark_env']['spark_worker_port']            = 7078
 default['spark']['spark_env']['spark_pid_dir']                = '/var/run/spark/'
-default['spark']['spark_env']['spark_history_server_log_dir'] = '/user/spark/applicationHistory'
+default['spark']['spark_env']['spark_history_server_log_dir'] = 'hdfs:///user/spark/applicationHistory'
 default['spark']['spark_env']['hadoop_conf_dir']              = '/etc/hadoop/conf'
+default['spark']['spark_env']['spark_dist_classpath']         = '$(hadoop classpath)'
 # spark-defaults.xml
-default['spark']['spark_defaults']['spark.eventLog.dir']               = '/user/spark/applicationHistory'
+default['spark']['spark_defaults']['spark.eventLog.dir']               = 'hdfs:///user/spark/applicationHistory'
 default['spark']['spark_defaults']['spark.eventLog.enabled']           = true
 default['spark']['spark_defaults']['spark.yarn.historyServer.address'] = "#{node['fqdn']}:10020"

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -34,11 +34,11 @@ eventlog_dir =
   if node['spark']['spark_defaults'].key?('spark.eventLog.dir')
     node['spark']['spark_defaults']['spark.eventLog.dir']
   else
-    '/user/spark/applicationHistory'
+    'hdfs:///user/spark/applicationHistory'
   end
 
 execute 'hdfs-spark-eventlog-dir' do
-  command "hdfs dfs -mkdir -p #{dfs}#{eventlog_dir} && hdfs dfs -chown -R spark:spark #{dfs}#{eventlog_dir} && hdfs dfs -chmod 1777 #{dfs}#{eventlog_dir}"
+  command "hdfs dfs -mkdir -p #{eventlog_dir} && hdfs dfs -chown -R spark:spark #{eventlog_dir} && hdfs dfs -chmod 1777 #{eventlog_dir}"
   user 'hdfs'
   group 'hdfs'
   timeout 300
@@ -81,7 +81,7 @@ template "/etc/init.d/#{pkg}" do
     'name' => pkg,
     'process' => 'java',
     'binary' => "#{hadoop_lib_dir}/spark/bin/spark-class",
-    'args' => 'org.apache.spark.deploy.history.HistoryServer > ${LOG_FILE} < /dev/null &',
+    'args' => 'org.apache.spark.deploy.history.HistoryServer > ${LOG_FILE} 2>&1 < /dev/null &',
     'confdir' => '${SPARK_CONF_DIR}',
     'user' => 'spark',
     'home' => "#{hadoop_lib_dir}/spark",

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -65,7 +65,7 @@ template "/etc/init.d/#{pkg}" do
     'process' => 'java',
     'binary' => "#{hadoop_lib_dir}/spark/bin/spark-class",
     'confdir' => '${SPARK_CONF_DIR}',
-    'args' => 'org.apache.spark.deploy.master.Master > ${LOG_FILE} < /dev/null &',
+    'args' => 'org.apache.spark.deploy.master.Master > ${LOG_FILE} 2>&1 < /dev/null &',
     'user' => 'spark',
     'home' => "#{hadoop_lib_dir}/spark",
     'pidfile' => "${SPARK_PID_DIR}/#{pkg}.pid",

--- a/recipes/spark_worker.rb
+++ b/recipes/spark_worker.rb
@@ -79,7 +79,7 @@ template "/etc/init.d/#{pkg}" do
     'name' => pkg,
     'process' => 'java',
     'binary' => "#{hadoop_lib_dir}/spark/bin/spark-class",
-    'args' => 'org.apache.spark.deploy.worker.Worker spark://${STANDALONE_SPARK_MASTER_HOST}:${SPARK_MASTER_PORT} > ${LOG_FILE} < /dev/null &',
+    'args' => 'org.apache.spark.deploy.worker.Worker spark://${STANDALONE_SPARK_MASTER_HOST}:${SPARK_MASTER_PORT} > ${LOG_FILE} 2>&1 < /dev/null &',
     'confdir' => '${SPARK_CONF_DIR}',
     'user' => 'spark',
     'home' => "#{hadoop_lib_dir}/spark",


### PR DESCRIPTION
Otherwise, running Spark commands fails on newer CDH distributions.