### PR TITLE
COOK-96 HDP 2.2+ log directories are not modified on Ubuntu

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -123,7 +123,11 @@ end # End fair-scheduler.xml
     # Prevent duplicate resources
     # rubocop:disable Style/Next
     unless node['hadoop'][envfile]["#{svc}_log_dir"] == "/var/log/hadoop-#{log_dir}" || (
-           hdp22? && node['hadoop'][envfile]["#{svc}_log_dir"] == "/var/log/hadoop/#{log_dir}")
+           hdp22? && (
+             (node['platform_family'] == 'debian' && node['hadoop'][envfile]["#{svc}_log_dir"] == "/var/log/hadoop-#{log_dir}") ||
+             (node['platform_family'] == 'rhel' && node['hadoop'][envfile]["#{svc}_log_dir"] == "/var/log/hadoop/#{log_dir}")
+           )
+    )
       # Delete default directory, if we aren't set to it
       directory "/var/log/hadoop-#{log_dir}" do
         action :delete
@@ -143,7 +147,7 @@ end # End fair-scheduler.xml
       # symlink HDP 2.2 log directory
       link "/var/log/hadoop/#{log_dir}" do
         to node['hadoop'][envfile]["#{svc}_log_dir"]
-        only_if { hdp22? }
+        only_if { hdp22? && node['platform_family'] == 'rhel' }
       end
     end
     # rubocop:enable Style/Next

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -120,14 +120,15 @@ end # End fair-scheduler.xml
       else
         svc
       end
+    default_log_dir =
+      if hdp22? && node['platform_family'] == 'rhel'
+        "/var/log/hadoop/#{log_dir}"
+      else
+        "/var/log/hadoop-#{log_dir}"
+      end
     # Prevent duplicate resources
     # rubocop:disable Style/Next
-    unless node['hadoop'][envfile]["#{svc}_log_dir"] == "/var/log/hadoop-#{log_dir}" || (
-           hdp22? && (
-             (node['platform_family'] == 'debian' && node['hadoop'][envfile]["#{svc}_log_dir"] == "/var/log/hadoop-#{log_dir}") ||
-             (node['platform_family'] == 'rhel' && node['hadoop'][envfile]["#{svc}_log_dir"] == "/var/log/hadoop/#{log_dir}")
-           )
-    )
+    unless node['hadoop'][envfile]["#{svc}_log_dir"] == default_log_dir
       # Delete default directory, if we aren't set to it
       directory "/var/log/hadoop-#{log_dir}" do
         action :delete


### PR DESCRIPTION
So Hortonworks only moves the HDFS log directory on HDP 2.2+ in their RPM packages. The DEB packages leave the directory in the default `/var/log/hadoop-hdfs` directory.

Thanks to @anwar6953 for finding this.