### PR TITLE
Setting YARN_LOG_DIR is a redundant test, use text-based

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -7,7 +7,7 @@ end
 
 # Restrict version due to Chef 12 requirement
 if RUBY_VERSION.to_f < 2.0
-  # cookbook 'mingw', '< 1.0'
+  cookbook 'apt', '< 4.0'
   cookbook 'build-essential', '< 3.0'
   cookbook 'ohai', '< 4.0'
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -14,7 +14,7 @@ describe 'hadoop::default' do
         node.default['hadoop']['fair_scheduler']['defaults']['poolMaxJobsDefault'] = '1000'
         node.default['hadoop']['container_executor']['banned.users'] = 'root'
         node.default['hadoop']['hadoop_env']['hadoop_log_dir'] = '/var/log/hadoop-hdfs'
-        node.default['hadoop']['yarn_env']['yarn_log_dir'] = '/var/log/hadoop-yarn'
+        node.default['hadoop']['yarn_env']['foo'] = 'bar'
         node.default['hadoop']['distribution'] = 'hdp'
         node.default['hadoop']['distribution_version'] = '2.3.4.7'
         stub_command(/update-alternatives --display /).and_return(false)
@@ -39,12 +39,6 @@ describe 'hadoop::default' do
           mode: '1777'
         )
       end
-    end
-
-    it 'creates /var/log/hadoop-yarn' do
-      expect(chef_run).to create_directory('/var/log/hadoop-yarn').with(
-        mode: '0775'
-      )
     end
 
     %w(
@@ -110,9 +104,9 @@ describe 'hadoop::default' do
       )
     end
 
-    it 'renders file yarn-env.sh with YARN_LOG_DIR' do
+    it 'renders file yarn-env.sh with FOO=bar' do
       expect(chef_run).to render_file('/etc/hadoop/conf.chef/yarn-env.sh').with_content(
-        /YARN_LOG_DIR/
+        /FOO=.bar/
       )
     end
 


### PR DESCRIPTION
Testing the *_LOG_DIR code is done in other contexts, so it's redundant here. Instead, simply set a KEY=VALUE pair to check.