### PR TITLE
COOK-100 ZooKeeper filesystem objects should use zookeeper group

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,7 +4,11 @@ group :integration do
   cookbook 'java', '~> 1.21'
 end
 
-# This is here until bmhatfield/chef-ulimit#41 is merged and a new version of the cookbook is released
-cookbook 'ulimit', github: 'wolf31o2/ulimit_cookbook', ref: 'feature/matchers'
+# Restrict version due to Chef 12 requirement
+if RUBY_VERSION.to_f < 2.0
+  # cookbook 'mingw', '< 1.0'
+  cookbook 'build-essential', '< 3.0'
+  cookbook 'ohai', '< 4.0'
+end
 
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,9 @@ group :integration do
   cookbook 'java', '~> 1.21'
 end
 
+# This is here until bmhatfield/chef-ulimit#41 is merged and a new version of the cookbook is released
+cookbook 'ulimit', github: 'wolf31o2/ulimit_cookbook', ref: 'feature/matchers'
+
 # Restrict version due to Chef 12 requirement
 if RUBY_VERSION.to_f < 2.0
   # cookbook 'mingw', '< 1.0'

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Recipe:: zookeeper_server
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ node.default['zookeeper']['zoocfg']['clientPort'] = zookeeper_client_port
 
 directory zookeeper_data_dir do
   owner 'zookeeper'
-  group 'hadoop'
+  group 'zookeeper'
   mode '0755'
   recursive true
   action :create
@@ -69,7 +69,7 @@ end
 
 directory "#{zookeeper_data_dir}/version-2" do
   owner 'zookeeper'
-  group 'hadoop'
+  group 'zookeeper'
   mode '0755'
   recursive true
   action :create
@@ -78,7 +78,7 @@ end
 unless zookeeper_datalog_dir == zookeeper_data_dir
   directory zookeeper_datalog_dir do
     owner 'zookeeper'
-    group 'hadoop'
+    group 'zookeeper'
     mode '0755'
     recursive true
     action :create
@@ -87,7 +87,7 @@ unless zookeeper_datalog_dir == zookeeper_data_dir
 
   directory "#{zookeeper_datalog_dir}/version-2" do
     owner 'zookeeper'
-    group 'hadoop'
+    group 'zookeeper'
     mode '0755'
     recursive true
     action :create

--- a/spec/zookeeper_server_spec.rb
+++ b/spec/zookeeper_server_spec.rb
@@ -71,7 +71,7 @@ describe 'hadoop::zookeeper_server' do
     it 'creates zookeeper dataDir' do
       expect(chef_run).to create_directory('/var/lib/zookeeper').with(
         user: 'zookeeper',
-        group: 'hadoop'
+        group: 'zookeeper'
       )
     end
 


### PR DESCRIPTION
Creating a standalone ZooKeeper system would otherwise fail. Also, installing ZooKeeper before other Hadoop components would fail.

Fixes [COOK-100](https://issues.cask.co/browse/COOK-100)