### PR TITLE
Use upstream ulimit cookbook for testing

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,10 +2,8 @@ source 'https://supermarket.chef.io'
 
 group :integration do
   cookbook 'java', '~> 1.21'
+  cookbook 'ulimit', '>= 0.4.0'
 end
-
-# This is here until bmhatfield/chef-ulimit#41 is merged and a new version of the cookbook is released
-cookbook 'ulimit', github: 'wolf31o2/ulimit_cookbook', ref: 'feature/matchers'
 
 # Restrict version due to Chef 12 requirement
 if RUBY_VERSION.to_f < 2.0

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rspec', '~> 3.0'
 if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
   gem 'varia_model', '< 0.5.0'
+  gem 'fauxhai', '< 3.5.0'
 else
   gem 'chef', '< 12.5' # Testing
 end


### PR DESCRIPTION
Our testing changes were merged upstream and a new version of the `ulimit` cookbook was released.