### PR TITLE
Restrict rack versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
   gem 'varia_model', '< 0.5.0'
   gem 'fauxhai', '< 3.5.0'
+  gem 'json', '< 2.0'
 else
   gem 'chef', '< 12.5' # Testing
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ else
 end
 
 gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
-
+gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
 gem 'rubocop'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,7 +26,7 @@ module Hadoop
       case cmd
       when 'disable'
         Chef::Log.info('Disabling package auto-start')
-        ::File.open('/usr/sbin/policy-rc.d', 'w', 0755) { |f| f.write('exit 101') }
+        ::File.open('/usr/sbin/policy-rc.d', 'w', 0o755) { |f| f.write('exit 101') }
       when 'enable'
         Chef::Log.info('Enabling package auto-start')
         ::File.delete('/usr/sbin/policy-rc.d') if ::File.exist?('/usr/sbin/policy-rc.d')


### PR DESCRIPTION
Newer `rack` versions require Ruby >= `2.2`