### PR TITLE
COOK-106 Split client and service JAAS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This cookbook may work on earlier versions, but these are the minimal tested ver
 
 * Chef 11.4.0+
 * CentOS 6.4+
+* Debian 6.0+
 * Ubuntu 12.04+
 
 This cookbook assumes that you have a working Java installation. It has been tested using version `1.21.2` of the `java` cookbook, using Oracle Java 6. If you plan on using Hive with a database other than the embedded Derby, you will need to provide it and set it up prior to starting Hive Metastore service.

--- a/recipes/_hbase_checkconfig.rb
+++ b/recipes/_hbase_checkconfig.rb
@@ -52,3 +52,14 @@ if node['hbase'].key?('jaas')
     Chef::Application.fatal!("You must set node['hbase']['jaas']['#{key}']['keytab'] and node['hbase']['jaas']['#{key}']['principal'] with node['hbase']['jaas'][key]['usekeytab']")
   end
 end
+
+%w(client master).each do |type|
+  next unless node['hbase'].key?("#{type}_jaas")
+  %w(client server).each do |key| # These are JAAS keys, not files
+    next unless node['hbase']["#{type}_jaas"].key?(key) && node['hbase']["#{type}_jaas"][key].key?('usekeytab') &&
+                node['hbase']["#{type}_jaas"][key]['usekeytab'].to_s == 'true'
+
+    next unless node['hbase']["#{type}_jaas"][key]['keytab'].nil? || node['hbase']["#{type}_jaas"][key]['principal'].nil?
+    Chef::Application.fatal!("You must set node['hbase']['#{type}_jaas']['#{key}']['keytab'] and node['hbase']['#{type}_jaas']['#{key}']['principal'] with node['hbase']['#{type}_jaas'][key]['usekeytab']")
+  end
+end

--- a/recipes/_hive_checkconfig.rb
+++ b/recipes/_hive_checkconfig.rb
@@ -37,3 +37,14 @@ if node['hive'].key?('jaas')
     Chef::Application.fatal!("You must set node['hive']['jaas']['#{key}']['keytab'] and node['hive']['jaas']['#{key}']['principal'] with node['hive']['jaas'][key]['usekeytab']")
   end
 end
+
+%w(client master).each do |type|
+  next unless node['hive'].key?("#{type}_jaas")
+  %w(client server).each do |key| # These are JAAS keys, not files
+    next unless node['hive']["#{type}_jaas"].key?(key) && node['hive']["#{type}_jaas"][key].key?('usekeytab') &&
+                node['hive']["#{type}_jaas"][key]['usekeytab'].to_s == 'true'
+
+    next unless node['hive']["#{type}_jaas"][key]['keytab'].nil? || node['hive']["#{type}_jaas"][key]['principal'].nil?
+    Chef::Application.fatal!("You must set node['hive']['#{type}_jaas']['#{key}']['keytab'] and node['hive']['#{type}_jaas']['#{key}']['principal'] with node['hive']['#{type}_jaas'][key]['usekeytab']")
+  end
+end

--- a/recipes/_storm_checkconfig.rb
+++ b/recipes/_storm_checkconfig.rb
@@ -27,3 +27,14 @@ if node['storm'].key?('jaas')
     Chef::Application.fatal!("You must set node['storm']['jaas']['#{key}']['keytab'] and node['storm']['jaas']['#{key}']['principal'] with node['storm']['jaas'][key]['usekeytab']")
   end
 end
+
+%w(client master).each do |type|
+  next unless node['storm'].key?("#{type}_jaas")
+  %w(client server).each do |key| # These are JAAS keys, not files
+    next unless node['storm']["#{type}_jaas"].key?(key) && node['storm']["#{type}_jaas"][key].key?('usekeytab') &&
+                node['storm']["#{type}_jaas"][key]['usekeytab'].to_s == 'true'
+
+    next unless node['storm']["#{type}_jaas"][key]['keytab'].nil? || node['storm']["#{type}_jaas"][key]['principal'].nil?
+    Chef::Application.fatal!("You must set node['storm']['#{type}_jaas']['#{key}']['keytab'] and node['storm']['#{type}_jaas']['#{key}']['principal'] with node['storm']['#{type}_jaas'][key]['usekeytab']")
+  end
+end

--- a/recipes/_zookeeper_checkconfig.rb
+++ b/recipes/_zookeeper_checkconfig.rb
@@ -27,3 +27,14 @@ if node['zookeeper'].key?('jaas')
     Chef::Application.fatal!("You must set node['zookeeper']['jaas']['#{key}']['keytab'] and node['zookeeper']['jaas']['#{key}']['principal'] with node['zookeeper']['jaas'][key]['usekeytab']")
   end
 end
+
+%w(client master).each do |type|
+  next unless node['zookeeper'].key?("#{type}_jaas")
+  %w(client server).each do |key| # These are JAAS keys, not files
+    next unless node['zookeeper']["#{type}_jaas"].key?(key) && node['zookeeper']["#{type}_jaas"][key].key?('usekeytab') &&
+                node['zookeeper']["#{type}_jaas"][key]['usekeytab'].to_s == 'true'
+
+    next unless node['zookeeper']["#{type}_jaas"][key]['keytab'].nil? || node['zookeeper']["#{type}_jaas"][key]['principal'].nil?
+    Chef::Application.fatal!("You must set node['zookeeper']['#{type}_jaas']['#{key}']['keytab'] and node['zookeeper']['#{type}_jaas']['#{key}']['principal'] with node['zookeeper']['#{type}_jaas'][key]['usekeytab']")
+  end
+end

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -114,6 +114,8 @@ if node['hbase'].key?('jaas') && node['hbase']['jaas'].key?('client')
     :client => node['hbase']['jaas']['client']
   }
 
+  log 'Single JAAS config deprecated. See COOK-106'
+
   template "#{hbase_conf_dir}/jaas.conf" do
     source 'jaas.conf.erb'
     mode '0644'
@@ -124,6 +126,25 @@ if node['hbase'].key?('jaas') && node['hbase']['jaas'].key?('client')
     only_if { node['hbase'].key?('jaas') && node['hbase']['jaas'].key?('client') }
   end
 end # End jaas.conf
+
+# Setup client_jaas.conf master_jaas.conf
+%w(client master).each do |type|
+  next unless node['hbase'].key?("#{type}_jaas") && node['hbase']["#{type}_jaas"].key?('client')
+  my_vars = {
+    # Only use client, for connecting to secure ZooKeeper
+    :client => node['hbase']["#{type}_jaas"]['client']
+  }
+
+  template "#{hbase_conf_dir}/#{type}_jaas.conf" do
+    source 'jaas.conf.erb'
+    mode '0644'
+    owner 'hbase'
+    group 'hbase'
+    action :create
+    variables my_vars
+    only_if { node['hbase'].key?("#{type}_jaas") && node['hbase']["#{type}_jaas"].key?('client') }
+  end
+end # End client_jaas.conf master_jaas.conf
 
 # limits.d settings
 ulimit_domain 'hbase' do

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -42,6 +42,25 @@ if node['hive'].key?('jaas')
   end
 end # End jaas.conf
 
+# Setup client_jaas.conf master_jaas.conf
+%w(client master).each do |type|
+  next unless node['hive'].key?("#{type}_jaas") && node['hive']["#{type}_jaas"].key?('client')
+  my_vars = {
+    # Only use client, for connecting to secure ZooKeeper
+    :client => node['hive']["#{type}_jaas"]['client']
+  }
+
+  template "#{hive_conf_dir}/#{type}_jaas.conf" do
+    source 'jaas.conf.erb'
+    mode '0644'
+    owner 'hive'
+    group 'hive'
+    action :create
+    variables my_vars
+    only_if { node['hive'].key?("#{type}_jaas") && node['hive']["#{type}_jaas"].key?('client') }
+  end
+end # End client_jaas.conf master_jaas.conf
+
 hive_log_dir =
   if node['hive'].key?('hive_env') && node['hive']['hive_env'].key?('hive_log_dir')
     node['hive']['hive_env']['hive_log_dir']

--- a/recipes/storm.rb
+++ b/recipes/storm.rb
@@ -177,6 +177,25 @@ template "#{storm_conf_dir}/jaas.conf" do
   end
 end # End jaas.conf
 
+# Setup client_jaas.conf master_jaas.conf
+%w(client master).each do |type|
+  next unless node['storm'].key?("#{type}_jaas") && node['storm']["#{type}_jaas"].key?('client')
+  my_vars = {
+    # Only use client, for connecting to secure ZooKeeper
+    :client => node['storm']["#{type}_jaas"]['client']
+  }
+
+  template "#{storm_conf_dir}/#{type}_jaas.conf" do
+    source 'jaas.conf.erb'
+    mode '0644'
+    owner 'storm'
+    group 'storm'
+    action :create
+    variables my_vars
+    only_if { node['storm'].key?("#{type}_jaas") && node['storm']["#{type}_jaas"].key?('client') }
+  end
+end # End client_jaas.conf master_jaas.conf
+
 # Update alternatives to point to our configuration
 execute 'update storm-conf alternatives' do
   command "update-alternatives --install /etc/storm/conf storm-conf /etc/storm/#{node['storm']['conf_dir']} 50"

--- a/recipes/zookeeper.rb
+++ b/recipes/zookeeper.rb
@@ -51,3 +51,25 @@ template "#{zookeeper_conf_dir}/jaas.conf" do
     node['zookeeper'].key?('jaas') && (!node['zookeeper']['jaas']['client'].empty? || !node['zookeeper']['jaas']['server'].empty)
   end
 end # End jaas.conf
+
+# Setup client_jaas.conf master_jaas.conf
+%w(client master).each do |type|
+  next unless node['zookeeper'].key?("#{type}_jaas")
+  my_vars = {
+    :client => node['zookeeper']["#{type}_jaas"]['client'],
+    :server => node['zookeeper']["#{type}_jaas"]['server']
+  }
+
+  template "#{zookeeper_conf_dir}/#{type}_jaas.conf" do
+    source 'jaas.conf.erb'
+    mode '0644'
+    owner 'root'
+    group 'root'
+    action :create
+    variables my_vars
+    only_if do
+      node['zookeeper'].key?("#{type}_jaas") && \
+        (!node['zookeeper']["#{type}_jaas"]['client'].empty? || !node['zookeeper']["#{type}_jaas"]['server'].empty)
+    end
+  end
+end # End client_jaas.conf master_jaas.conf


### PR DESCRIPTION
Support `client_jaas.conf` and `master_jaas.conf` each with their own Client and Server sections. Otherwise, using these clients would authenticate to ZooKeeper as the service, rather than the user running the command.