### PR TITLE
Remove policy_rcd; should use dpkg_autostart cookbook, instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rspec', '~> 3.0'
 
 if RUBY_VERSION.to_f < 2.1
   gem 'chef-zero', '< 4.6'
-  gem 'fauxhai', '< 3.7'
+  gem 'fauxhai', '< 3.7' unless RUBY_VERSION.to_f < 2.0
   gem 'ffi-yajl', '< 2.3'
   gem 'buff-ignore', '< 1.2'
 else

--- a/Gemfile
+++ b/Gemfile
@@ -7,21 +7,20 @@ gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
 if RUBY_VERSION.to_f < 2.1
-  gem 'chef-zero', '< 4.6'
-  gem 'fauxhai', '< 3.7' unless RUBY_VERSION.to_f < 2.0
-  gem 'ffi-yajl', '< 2.3'
   gem 'buff-ignore', '< 1.2'
-else
-  gem 'chef', '< 12.5'
-  gem 'rubocop'
+  gem 'chef-zero', '< 4.6'
+  gem 'fauxhai', '< 3.5'
+  gem 'ffi-yajl', '< 2.3'
 end
 
 if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
-  gem 'varia_model', '< 0.5.0'
-  gem 'fauxhai', '< 3.5.0'
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
+  gem 'varia_model', '< 0.5.0'
+else
+  gem 'chef', '< 12.5'
+  gem 'rubocop'
 end
 
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,12 @@ else
   gem 'rubocop'
 end
 
-gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
-gem 'ffi-yajl', '< 2.3' if RUBY_VERSION.to_f < 2.1
+if RUBY_VERSION.to_f < 2.1
+  gem 'chef-zero', '< 4.6'
+  gem 'ffi-yajl', '< 2.3'
+  gem 'buff-ignore', '< 1.2'
+end
+
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'

--- a/Gemfile
+++ b/Gemfile
@@ -6,21 +6,20 @@ gem 'foodcritic', '~> 4.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
-if RUBY_VERSION.to_f < 2.0
+if RUBY_VERSION.to_f < 2.1
+  gem 'chef-zero', '< 4.6'
+  gem 'fauxhai', '< 3.7'
+  gem 'ffi-yajl', '< 2.3'
+  gem 'buff-ignore', '< 1.2'
+elsif RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
   gem 'varia_model', '< 0.5.0'
   gem 'fauxhai', '< 3.5.0'
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
 else
-  gem 'chef', '< 12.5' # Testing
+  gem 'chef', '< 12.5'
   gem 'rubocop'
-end
-
-if RUBY_VERSION.to_f < 2.1
-  gem 'chef-zero', '< 4.6'
-  gem 'ffi-yajl', '< 2.3'
-  gem 'buff-ignore', '< 1.2'
 end
 
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -11,15 +11,17 @@ if RUBY_VERSION.to_f < 2.1
   gem 'fauxhai', '< 3.7'
   gem 'ffi-yajl', '< 2.3'
   gem 'buff-ignore', '< 1.2'
-elsif RUBY_VERSION.to_f < 2.0
+else
+  gem 'chef', '< 12.5'
+  gem 'rubocop'
+end
+
+if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
   gem 'varia_model', '< 0.5.0'
   gem 'fauxhai', '< 3.5.0'
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
-else
-  gem 'chef', '< 12.5'
-  gem 'rubocop'
 end
 
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ if RUBY_VERSION.to_f < 2.1
   gem 'chef-zero', '< 4.6'
   gem 'fauxhai', '< 3.5'
   gem 'ffi-yajl', '< 2.3'
+  gem 'dep_selector', '< 1.0.4'
 end
 
 if RUBY_VERSION.to_f < 2.0

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop
 # Library:: helpers
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,22 +19,6 @@
 
 module Hadoop
   module Helpers
-    #
-    # Disable service auto-start on Debian-based platforms
-    #
-    def policy_rcd(cmd)
-      case cmd
-      when 'disable'
-        Chef::Log.info('Disabling package auto-start')
-        ::File.open('/usr/sbin/policy-rc.d', 'w', 0o755) { |f| f.write('exit 101') }
-      when 'enable'
-        Chef::Log.info('Enabling package auto-start')
-        ::File.delete('/usr/sbin/policy-rc.d') if ::File.exist?('/usr/sbin/policy-rc.d')
-      else
-        Chef::Application.fatal!('The policy_rc.d method only accepts "disable" or "enable" as arguments')
-      end
-    end
-
     #
     # Return HDP 2.2 version, including revision, used for building HDP 2.2+ on-disk paths
     #

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "yum": ">= 3.0",
     "apt": ">= 2.1.2",
+    "dpkg_autostart": ">= 0.0.0",
     "selinux": ">= 0.0.0",
     "sysctl": ">= 0.0.0",
     "ulimit": ">= 0.0.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version          '2.4.1'
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'
 
-%w(selinux sysctl ulimit).each do |cb|
+%w(dpkg_autostart selinux sysctl ulimit).each do |cb|
   depends cb
 end
 

--- a/recipes/flume_agent.rb
+++ b/recipes/flume_agent.rb
@@ -26,20 +26,12 @@ pkg =
     hadoop_package('flume-agent')
   end
 
-package pkg do
-  action :nothing
+dpkg_autostart pkg do
+  allow false
 end
 
-# Hack to prevent auto-start of services, see COOK-26
-ruby_block "package-#{pkg}" do
-  block do
-    begin
-      policy_rcd('disable') if node['platform_family'] == 'debian'
-      resources("package[#{pkg}]").run_action(:install)
-    ensure
-      policy_rcd('enable') if node['platform_family'] == 'debian'
-    end
-  end
+package pkg do
+  action :install
 end
 
 service 'flume-agent' do

--- a/recipes/hadoop_mapreduce_jobtracker.rb
+++ b/recipes/hadoop_mapreduce_jobtracker.rb
@@ -47,22 +47,12 @@ mapred_local_dirs.split(',').each do |dir|
   end
 end
 
-package pkg do
-  action :nothing
+dpkg_autostart pkg do
+  allow false
 end
 
-# Hack to prevent auto-start of services, see COOK-26
-ruby_block "package-#{pkg}" do
-  block do
-    begin
-      policy_rcd('disable') if node['platform_family'] == 'debian'
-      resources("package[#{pkg}]").run_action(:install)
-    ensure
-      policy_rcd('enable') if node['platform_family'] == 'debian'
-    end
-  end
-  # Only CDH supports a JobTracker package
-  only_if { node['hadoop']['distribution'] == 'cdh' }
+package pkg do
+  action :install
 end
 
 service pkg do

--- a/recipes/hadoop_mapreduce_jobtracker.rb
+++ b/recipes/hadoop_mapreduce_jobtracker.rb
@@ -49,10 +49,12 @@ end
 
 dpkg_autostart pkg do
   allow false
+  only_if { node['hadoop']['distribution'] == 'cdh' }
 end
 
 package pkg do
   action :install
+  only_if { node['hadoop']['distribution'] == 'cdh' }
 end
 
 service pkg do

--- a/recipes/hadoop_mapreduce_tasktracker.rb
+++ b/recipes/hadoop_mapreduce_tasktracker.rb
@@ -42,22 +42,12 @@ mapred_local_dirs.split(',').each do |dir|
   end
 end
 
-package pkg do
-  action :nothing
+dpkg_autostart pkg do
+  allow false
 end
 
-# Hack to prevent auto-start of services, see COOK-26
-ruby_block "package-#{pkg}" do
-  block do
-    begin
-      policy_rcd('disable') if node['platform_family'] == 'debian'
-      resources("package[#{pkg}]").run_action(:install)
-    ensure
-      policy_rcd('enable') if node['platform_family'] == 'debian'
-    end
-  end
-  # Only CDH supports a TaskTracker package
-  only_if { node['hadoop']['distribution'] == 'cdh' }
+package pkg do
+  action :install
 end
 
 service pkg do

--- a/recipes/hadoop_mapreduce_tasktracker.rb
+++ b/recipes/hadoop_mapreduce_tasktracker.rb
@@ -44,10 +44,12 @@ end
 
 dpkg_autostart pkg do
   allow false
+  only_if { node['hadoop']['distribution'] == 'cdh' }
 end
 
 package pkg do
   action :install
+  only_if { node['hadoop']['distribution'] == 'cdh' }
 end
 
 service pkg do

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -22,19 +22,11 @@ include_recipe 'hadoop::oozie_client'
 pkg = hadoop_package('oozie')
 
 package pkg do
-  action :nothing
+  action :install
 end
 
-# Hack to prevent auto-start of services, see COOK-26
-ruby_block "package-#{pkg}" do
-  block do
-    begin
-      policy_rcd('disable') if node['platform_family'] == 'debian'
-      resources("package[#{pkg}]").run_action(:install)
-    ensure
-      policy_rcd('enable') if node['platform_family'] == 'debian'
-    end
-  end
+package pkg do
+  action :install
 end
 
 oozie_conf_dir = "/etc/oozie/#{node['oozie']['conf_dir']}"

--- a/spec/flume_agent_spec.rb
+++ b/spec/flume_agent_spec.rb
@@ -10,12 +10,8 @@ describe 'hadoop::flume_agent' do
       end.converge(described_recipe)
     end
 
-    it 'does not install flume-agent package' do
-      expect(chef_run).not_to install_package('flume_2_3_4_7_4-agent')
-    end
-
-    it 'runs package-flume-agent ruby_block' do
-      expect(chef_run).to run_ruby_block('package-flume_2_3_4_7_4-agent')
+    it 'install flume-agent package' do
+      expect(chef_run).to install_package('flume_2_3_4_7_4-agent')
     end
 
     it 'creates flume-agent service resource, but does not run it' do
@@ -31,12 +27,8 @@ describe 'hadoop::flume_agent' do
       end.converge(described_recipe)
     end
 
-    it 'does not install flume-ng package' do
-      expect(chef_run).not_to install_package('flume-ng-agent')
-    end
-
-    it 'runs package-flume-ng-agent ruby_block' do
-      expect(chef_run).to run_ruby_block('package-flume-ng-agent')
+    it 'install flume-ng package' do
+      expect(chef_run).to install_package('flume-ng-agent')
     end
   end
 end

--- a/spec/hadoop_mapreduce_jobtracker_spec.rb
+++ b/spec/hadoop_mapreduce_jobtracker_spec.rb
@@ -13,12 +13,8 @@ describe 'hadoop::hadoop_mapreduce_jobtracker' do
     end
     pkg = 'hadoop-0.20-mapreduce-jobtracker'
 
-    it "does not install #{pkg} package" do
-      expect(chef_run).not_to install_package(pkg)
-    end
-
-    it "runs package-#{pkg} ruby_block" do
-      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    it "install #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
     end
 
     it "creates #{pkg} service resource, but does not run it" do

--- a/spec/hadoop_mapreduce_tasktracker_spec.rb
+++ b/spec/hadoop_mapreduce_tasktracker_spec.rb
@@ -13,12 +13,8 @@ describe 'hadoop::hadoop_mapreduce_tasktracker' do
     end
     pkg = 'hadoop-0.20-mapreduce-tasktracker'
 
-    it "does not install #{pkg} package" do
-      expect(chef_run).not_to install_package(pkg)
-    end
-
-    it "runs package-#{pkg} ruby_block" do
-      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    it "install #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
     end
 
     it "creates #{pkg} service resource, but does not run it" do
@@ -40,9 +36,10 @@ describe 'hadoop::hadoop_mapreduce_tasktracker' do
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'hadoop-0.20-mapreduce-tasktracker'
 
-    it 'does not install hadoop-0.20-mapreduce-tasktracker package' do
-      expect(chef_run).not_to install_package('hadoop-0.20-mapreduce-tasktracker')
+    it "does not install #{pkg} package" do
+      expect(chef_run).not_to install_package(pkg)
     end
   end
 end

--- a/spec/oozie_spec.rb
+++ b/spec/oozie_spec.rb
@@ -16,12 +16,8 @@ describe 'hadoop::oozie' do
     name = 'oozie'
     pkg = 'oozie_2_3_4_7_4'
 
-    it "does not install #{name} package" do
-      expect(chef_run).not_to install_package(pkg)
-    end
-
-    it "runs package-#{pkg} ruby_block" do
-      expect(chef_run).to run_ruby_block("package-#{pkg}")
+    it "install #{name} package" do
+      expect(chef_run).to install_package(pkg)
     end
 
     it "creates #{name} service resource, but does not run it" do
@@ -78,6 +74,22 @@ describe 'hadoop::oozie' do
 
     it 'runs execute[update oozie-conf alternatives]' do
       expect(chef_run).to run_execute('update oozie-conf alternatives')
+    end
+  end
+
+  context 'on Centos 6.6 with HDP' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
+        stub_command(/test -L /).and_return(false)
+      end.converge(described_recipe)
+    end
+    pkg = 'oozie'
+
+    it "install #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
     end
   end
 end

--- a/spec/oozie_spec.rb
+++ b/spec/oozie_spec.rb
@@ -77,10 +77,12 @@ describe 'hadoop::oozie' do
     end
   end
 
-  context 'on Centos 6.6 with HDP' do
+  context 'on Centos 6.6 with CDH' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
+        node.default['hadoop']['distribution'] = 'cdh'
+        node.default['hadoop']['distribution_version'] = '5.7.0'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
         stub_command(/test -L /).and_return(false)

--- a/spec/oozie_spec.rb
+++ b/spec/oozie_spec.rb
@@ -81,8 +81,8 @@ describe 'hadoop::oozie' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
-        node.default['hadoop']['distribution'] = 'cdh'
-        node.default['hadoop']['distribution_version'] = '5.7.0'
+        node.override['hadoop']['distribution'] = 'cdh'
+        node.override['hadoop']['distribution_version'] = '5.7.0'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(%r{/sys/kernel/mm/(.*)transparent_hugepage/defrag}).and_return(false)
         stub_command(/test -L /).and_return(false)


### PR DESCRIPTION
This method is completely unused in this cookbook and the functionality is provided by the `dpkg_autostart` cookbook. Removing the function from our cookbook.