### PR TITLE
Use major_platform_version for centos5 or HDP >= 2.3

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -85,7 +85,7 @@ when 'hdp'
   case node['platform_family']
   when 'rhel'
     yum_base_url = 'http://public-repo-1.hortonworks.com/HDP'
-    os = if major_platform_version == 5
+    os = if major_platform_version == 5 || hdp_version.to_f >= 2.3
            "centos#{major_platform_version}"
          else
            'centos6'


### PR DESCRIPTION
HDP has packages for `centos7` starting with `2.3.0.0` release.

<img width="417" alt="screen shot 2016-08-30 at 4 49 57 pm" src="https://cloud.githubusercontent.com/assets/380021/18106487/ec424e46-6ed1-11e6-9763-97ed63ddc6f0.png">
