### PR TITLE
Support IOP 4.2.0.0 (and others)

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -312,14 +312,9 @@ when 'bigtop'
   end
 
 when 'iop'
-  case node['hadoop']['distribution_version']
-  ### TODO: 4.0 support?
-  when '4.1.0.0'
-    iop_version = node['hadoop']['distribution_version']
-    iop_release = "#{node['hadoop']['distribution_version'].to_f}.x"
-  end
-
-  iop_utils_version = '1.1.0.0'
+  iop_version = node['hadoop']['distribution_version']
+  iop_release = "#{node['hadoop']['distribution_version'].to_f}.x"
+  iop_utils_version = '1.2.0.0'
 
   case node['platform_family']
   when 'rhel'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -38,7 +38,7 @@ describe 'hadoop::repo' do
       end.converge(described_recipe)
     end
 
-    %w(IOP-4.1.x IOP-UTILS-1.1.0.0).each do |repo|
+    %w(IOP-4.1.x IOP-UTILS-1.2.0.0).each do |repo|
       it "add #{repo} yum_repository" do
         expect(chef_run).to add_yum_repository(repo)
       end


### PR DESCRIPTION
It appears that the IOP repository has a standard layout, so we do not need to be explicit about our supported versions.