### PR TITLE
set distribution_version default in attributes instead of recipes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,20 @@
 # Supported: cdh, hdp, bigtop, iop
 default['hadoop']['distribution'] = 'hdp'
 
+# Set defaults for version, based on distribution
+default['hadoop']['distribution_version'] =
+  if node['hadoop'].key?('distribution_version')
+    node['hadoop']['distribution_version']
+  elsif node['hadoop']['distribution'] == 'hdp'
+    '2.3.4.7'
+  elsif node['hadoop']['distribution'] == 'cdh'
+    '5.6.0'
+  elsif node['hadoop']['distribution'] == 'bigtop'
+    '1.0.0'
+  elsif node['hadoop']['distribution'] == 'iop'
+    '4.1.0.0'
+  end
+
 default['hadoop']['force_format'] = false
 
 # Default: conf.chef

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -23,20 +23,6 @@ key = 'RPM-GPG-KEY'
 # Ensure apt caches are updated and apt resources available
 include_recipe 'apt' if node['platform_family'] == 'debian'
 
-# Set defaults for version, based on distribution
-node.default['hadoop']['distribution_version'] =
-  if node['hadoop'].key?('distribution_version')
-    node['hadoop']['distribution_version']
-  elsif node['hadoop']['distribution'] == 'hdp'
-    '2.3.4.7'
-  elsif node['hadoop']['distribution'] == 'cdh'
-    '5.6.0'
-  elsif node['hadoop']['distribution'] == 'bigtop'
-    '1.0.0'
-  elsif node['hadoop']['distribution'] == 'iop'
-    '4.1.0.0'
-  end
-
 case node['hadoop']['distribution']
 when 'hdp'
   case node['hadoop']['distribution_version']


### PR DESCRIPTION
this sets the default ``['hadoop']['distribution_version']`` attribute in ``attributes/default.rb`` instead of ``recipes/repo.rb``.  Otherwise, we have conditionals in the attribute files that use this attribute before the default is set, such as https://github.com/caskdata/hadoop_cookbook/blob/master/attributes/default.rb#L123