### PR TITLE
Disable Metrics/BlockLength and alphabetize

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,13 +10,15 @@ Style/SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
   Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
-Metrics/AbcSize:
+Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
-  Enabled: false
-Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
Newer Rubocop rules limit block length. We don't want this.