### PR TITLE
Move storm-env.sh creation to storm recipe

### DIFF
--- a/recipes/storm.rb
+++ b/recipes/storm.rb
@@ -94,6 +94,17 @@ unless storm_conf_dir == "#{node['storm']['storm_env']['storm_home']}/conf"
   end
 end
 
+# Start storm-env.sh
+template "#{storm_conf_dir}/#{pkg}-env.sh" do
+  source 'generic-env.sh.erb'
+  mode '0755'
+  owner 'root'
+  group 'root'
+  action :create
+  variables :options => node['storm']['storm_env']
+  only_if { node['storm'].key?('storm_env') && !node['storm']['storm_env'].empty? }
+end # End storm-env.sh
+
 template "#{storm_conf_dir}/storm.yaml" do
   source 'storm.yaml.erb'
   mode '0644'

--- a/recipes/storm_nimbus.rb
+++ b/recipes/storm_nimbus.rb
@@ -3,6 +3,7 @@
 # Recipe:: storm_nimbus
 #
 # Copyright © 2015 VAHNA
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'yaml'
 
 include_recipe 'hadoop::storm'
 
@@ -57,17 +57,6 @@ template "/etc/init.d/#{pkg}" do
     'logfile' => "${STORM_LOG_DIR}/#{pkg}.log"
   }
 end
-
-# Start storm-env.sh
-template "#{storm_conf_dir}/#{pkg}-env.sh" do
-  source 'generic-env.sh.erb'
-  mode '0755'
-  owner 'root'
-  group 'root'
-  action :create
-  variables :options => node['storm']['storm_env']
-  only_if { node['storm'].key?('storm_env') && !node['storm']['storm_env'].empty? }
-end # End storm-env.sh
 
 # Create /etc/default configuration
 template "/etc/default/#{pkg}" do

--- a/recipes/storm_supervisor.rb
+++ b/recipes/storm_supervisor.rb
@@ -3,6 +3,7 @@
 # Recipe:: storm_supervisor
 #
 # Copyright © 2015 VAHNA
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'yaml'
 
 include_recipe 'hadoop::storm'
 
@@ -57,17 +57,6 @@ template "/etc/init.d/#{pkg}" do
     'logfile' => "${STORM_LOG_DIR}/#{pkg}.log"
   }
 end
-
-# Start storm-env.sh
-template "#{storm_conf_dir}/#{pkg}-env.sh" do
-  source 'generic-env.sh.erb'
-  mode '0755'
-  owner 'root'
-  group 'root'
-  action :create
-  variables :options => node['storm']['storm_env']
-  only_if { node['storm'].key?('storm_env') && !node['storm']['storm_env'].empty? }
-end # End storm-env.sh
 
 # Create /etc/default configuration
 template "/etc/default/#{pkg}" do

--- a/recipes/storm_ui.rb
+++ b/recipes/storm_ui.rb
@@ -3,6 +3,7 @@
 # Recipe:: storm_ui
 #
 # Copyright © 2015 VAHNA
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'yaml'
 
 include_recipe 'hadoop::storm'
 
@@ -57,17 +57,6 @@ template "/etc/init.d/#{pkg}" do
     'logfile' => "${STORM_LOG_DIR}/#{pkg}.log"
   }
 end
-
-# Start storm-env.sh
-template "#{storm_conf_dir}/#{pkg}-env.sh" do
-  source 'generic-env.sh.erb'
-  mode '0755'
-  owner 'root'
-  group 'root'
-  action :create
-  variables :options => node['storm']['storm_env']
-  only_if { node['storm'].key?('storm_env') && !node['storm']['storm_env'].empty? }
-end # End storm-env.sh
 
 # Create /etc/default configuration
 template "/etc/default/#{pkg}" do

--- a/spec/storm_nimbus_spec.rb
+++ b/spec/storm_nimbus_spec.rb
@@ -17,7 +17,6 @@ describe 'hadoop::storm_nimbus' do
     %W(
       /etc/default/#{pkg}
       /etc/init.d/#{pkg}
-      /etc/storm/conf.chef/#{pkg}-env.sh
     ).each do |file|
       it "creates #{file} from template" do
         expect(chef_run).to create_template(file)

--- a/spec/storm_spec.rb
+++ b/spec/storm_spec.rb
@@ -8,7 +8,7 @@ describe 'hadoop::storm' do
         node.default['hadoop']['distribution'] = 'hdp'
         node.default['hadoop']['distribution_version'] = '2.3.4.7'
         node.default['storm']['release']['install'] = false
-        node.default['storm']['jaas']['client']['foo'] = 'bar'
+        node.default['storm']['client_jaas']['client']['foo'] = 'bar'
         stub_command(/test -L /).and_return(false)
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)
@@ -18,8 +18,10 @@ describe 'hadoop::storm' do
       expect(chef_run).to install_package('storm_2_3_4_7_4')
     end
 
-    it 'creates /etc/storm/conf.chef/jaas.conf from template' do
-      expect(chef_run).to create_template('/etc/storm/conf.chef/jaas.conf')
+    %w(client_jaas.conf storm-env.sh).each do |template|
+      it "creates /etc/storm/conf.chef/#{template} from template" do
+        expect(chef_run).to create_template("/etc/storm/conf.chef/#{template}")
+      end
     end
 
     it 'deletes /etc/storm/conf directory' do

--- a/spec/storm_supervisor_spec.rb
+++ b/spec/storm_supervisor_spec.rb
@@ -17,7 +17,6 @@ describe 'hadoop::storm_supervisor' do
     %W(
       /etc/default/#{pkg}
       /etc/init.d/#{pkg}
-      /etc/storm/conf.chef/#{pkg}-env.sh
     ).each do |file|
       it "creates #{file} from template" do
         expect(chef_run).to create_template(file)

--- a/spec/storm_ui_spec.rb
+++ b/spec/storm_ui_spec.rb
@@ -17,7 +17,6 @@ describe 'hadoop::storm_ui' do
     %W(
       /etc/default/#{pkg}
       /etc/init.d/#{pkg}
-      /etc/storm/conf.chef/#{pkg}-env.sh
     ).each do |file|
       it "creates #{file} from template" do
         expect(chef_run).to create_template(file)


### PR DESCRIPTION
This was duplicated into each service recipe, versus being in the main `storm` recipe.