### PR TITLE
Version bump to 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ hadoop CHANGELOG
 
 v2.7.1 (Oct 25, 2016)
 ---------------------
-- Add non-cookbook files to chefignore ( Issue #298)
 - Switch to new Ruby hash syntax ( Issue #297)
+- Add non-cookbook files to chefignore ( Issue #298)
 - Support for Spark on IOP ( Issue #299 )
 
 v2.7.0 (Oct 17, 2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 hadoop CHANGELOG
 ===============
 
+v2.7.1 (Oct 25, 2016)
+---------------------
+- Add non-cookbook files to chefignore ( Issue #298)
+- Switch to new Ruby hash syntax ( Issue #297)
+- Support for Spark on IOP ( Issue #299 )
+
 v2.7.0 (Oct 17, 2016)
 ---------------------
 - Pull in code from forks ( Issue #282 )

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
   "recipes": {
 
   },
-  "version": "2.7.0",
+  "version": "2.7.1",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.7.0'
+version          '2.7.1'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
Includes:
- Add non-cookbook files to chefignore ( Issue #298)
- Switch to new Ruby hash syntax ( Issue #297)
- Support for Spark on IOP ( Issue #299 )
