### PR TITLE
Disable FC053 inline for recommends

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ depends 'apt', '>= 2.1.2'
   depends cb
 end
 
-recommends 'java', '~> 1.40'
+recommends 'java', '~> 1.40' # ~FC053
 
 %w(
   amazon


### PR DESCRIPTION
This will fix the failing foodcritic at https://supermarket.chef.io/cookbooks/hadoop#quality