### PR TITLE
Increase mass threshold to catch actual duplicates only

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ engines:
     config:
       languages:
       - ruby
-        #mass_threshold: 20
+        #mass_threshold: 60
   fixme:
     enabled: true
   foodcritic:


### PR DESCRIPTION
This will remove duplicates such as the init scripts from duplication reports, as they're expected to be similar code.
