### PR TITLE
COOK-107 Use Java cookbook jdk.sh before BigTop tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,39 +7,47 @@ gem 'rspec', '~> 3.0'
 
 if RUBY_VERSION.to_f < 2.2
   gem 'rack', '< 2.0'
+  # rubocop: disable Lint/UnneededDisable
+  # rubocop: disable Bundler/DuplicatedGem
   if RUBY_VERSION.to_f < 2.1
     gem 'fauxhai', '< 3.5'
   else
     gem 'fauxhai', '< 3.10'
   end
+  # rubocop: enable Bundler/DuplicatedGem
+  # rubocop: enable Lint/UnneededDisable
 end
 
 if RUBY_VERSION.to_f < 2.1
   gem 'buff-ignore', '< 1.2'
   gem 'chef-zero', '< 4.6'
-  gem 'ffi-yajl', '< 2.3'
   gem 'dep_selector', '< 1.0.4'
+  gem 'ffi-yajl', '< 2.3'
   gem 'net-http-persistent', '< 3.0'
 end
 
 if RUBY_VERSION.to_f < 2.0
+  # rubocop: disable Lint/UnneededDisable
+  # rubocop: disable Bundler/DuplicatedGem
   gem 'chef', '< 12.0'
+  gem 'foodcritic', '~> 4.0'
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
   gem 'varia_model', '< 0.5.0'
-  gem 'foodcritic', '~> 4.0'
 else
   gem 'chef', '< 12.5'
   gem 'foodcritic', '~> 6.0'
   gem 'rubocop'
+  # rubocop: enable Bundler/DuplicatedGem
+  # rubocop: enable Lint/UnneededDisable
 end
 
-gem 'ridley', '~> 4.2.0'
+gem 'dep-selector-libgecode', '< 1.3.1'
 gem 'faraday', '< 0.9.2'
 gem 'rainbow', '<= 1.99.1'
-gem 'dep-selector-libgecode', '< 1.3.1'
+gem 'ridley', '~> 4.2.0'
 
 group :integration do
-  gem 'test-kitchen'
   gem 'kitchen-vagrant'
+  gem 'test-kitchen'
 end

--- a/templates/default/hadoop-init.erb
+++ b/templates/default/hadoop-init.erb
@@ -36,8 +36,9 @@
 . /lib/lsb/init-functions
 [ -f /etc/default/hadoop ] && . /etc/default/hadoop
 
-# Autodetect JAVA_HOME if not defined
+# Source java cookbook's profile file, if it exists
 [ -f /etc/profile.d/jdk.sh ] && . /etc/profile.d/jdk.sh
+# Autodetect JAVA_HOME if not defined
 if [ -e /usr/libexec/bigtop-detect-javahome ]; then
   . /usr/libexec/bigtop-detect-javahome
 elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then

--- a/templates/default/hadoop-init.erb
+++ b/templates/default/hadoop-init.erb
@@ -37,12 +37,12 @@
 [ -f /etc/default/hadoop ] && . /etc/default/hadoop
 
 # Autodetect JAVA_HOME if not defined
+[ -f /etc/profile.d/jdk.sh ] && . /etc/profile.d/jdk.sh
 if [ -e /usr/libexec/bigtop-detect-javahome ]; then
   . /usr/libexec/bigtop-detect-javahome
 elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
   . /usr/lib/bigtop-utils/bigtop-detect-javahome
 fi
-[ -f /etc/profile.d/jdk.sh ] && . /etc/profile.d/jdk.sh
 
 RETVAL_SUCCESS=0
 


### PR DESCRIPTION
This will source the Java cookbook's `jdk.sh` prior to running the BigTop tools for detecting JAVA_HOME, which works for Java set outside the `java` cookbook.