### PR TITLE
Version bump to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 hadoop CHANGELOG
 ===============
 
+v2.8.0 (Dec 6, 2016)
+--------------------
+- Updates to testing configurations ( Issues: #301 #302 #304 )
+- Update HDP versions when short versions given ( Issue: #303 )
+- Support 2015 and 2016 Amazon Linux AMIs ( Issue: #305 )
+- Use Java cookbook jdk.sh before BigTop tools ( Issues: #306 [COOK-107](https://issues.cask.co/browse/COOK-107) )
+- Hive logging support ( Issues: #307 [COOK-111](https://issues.cask.co/browse/COOK-111) )
+- Fix hadoop-mapreduce-historyserver stop ( Issue: #308 )
+
 v2.7.1 (Oct 25, 2016)
 ---------------------
 - Switch to new Ruby hash syntax ( Issue #297)

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
   "recipes": {
 
   },
-  "version": "2.7.1",
+  "version": "2.8.0",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.7.1'
+version          '2.8.0'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
Includes:

- Updates to testing configurations ( Issues: #301 #302 #304 )
- Update HDP versions when short versions given ( Issue: #303 )
- Support 2015 and 2016 Amazon Linux AMIs ( Issue: #305 )
- Use Java cookbook jdk.sh before BigTop tools ( Issues: #306 [COOK-107](https://issues.cask.co/browse/COOK-107) )
- Hive logging support ( Issues: #307 [COOK-111](https://issues.cask.co/browse/COOK-111) )
- Fix hadoop-mapreduce-historyserver stop ( Issue: #308 )