### PR TITLE
Version bump to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 hadoop CHANGELOG
 ===============
 
+v2.9.0 (Dec 13, 2016)
+---------------------
+- Update CDH/HDP default versions ( Issue: #310 )
+- Support HDP 2.5.3.0 ( Issue: #311 )
+
 v2.8.0 (Dec 6, 2016)
 --------------------
 - Updates to testing configurations ( Issues: #301 #302 #304 )

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
   "recipes": {
 
   },
-  "version": "2.8.0",
+  "version": "2.9.0",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.8.0'
+version          '2.9.0'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
Includes fix for `CVE-2016-5393` on CDH/HDP (by default):

- Update CDH/HDP default versions ( Issue: #310 )
- Support HDP 2.5.3.0 ( Issue: #311 )