### PR TITLE
Match more files in chefignore

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -48,6 +48,8 @@ a.out
 .watchr
 .rspec
 .rubocop.yml
+.rubocop_todo.yml
+.kitchen.yml
 .codeclimate.yml
 spec/*
 spec/fixtures/*
@@ -82,8 +84,9 @@ tmp
 
 # Cookbooks #
 #############
-CONTRIBUTING
+CONTRIBUTING*
 CHANGELOG*
+chefignore
 
 # Strainer #
 ############


### PR DESCRIPTION
We don't need to push our Rubocop or Test Kitchen configurations with the cookbook to Supermarket.