### PR TITLE
Explicitly require 'chef/version' before using Chef::VERSION

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,7 @@
 source 'https://supermarket.chef.io'
 
+require 'chef/version'
+
 if Chef::VERSION.to_f < 12.0
   cookbook 'apt', '< 4.0'
   cookbook 'build-essential', '< 3.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -26,3 +26,4 @@ end
 
 source_url 'https://github.com/caskdata/hadoop_cookbook' if respond_to?(:source_url)
 issues_url 'https://issues.cask.co/browse/COOK/component/10600' if respond_to?(:issues_url)
+chef_version '>= 11' if respond_to?(:chef_version)


### PR DESCRIPTION
Otherwise, it fails when using tools which use berkshelf but don't already initialize Chef on their own, such as... `berks`.