### PR TITLE
Properly configure mass_threshold and inline disable FC023

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,8 +4,8 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
-        #mass_threshold: 60
+        ruby:
+          mass_threshold: 60
   fixme:
     enabled: true
   foodcritic:

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -41,7 +41,7 @@ dfs_data_dirs.split(',').each do |dir|
   end
 end
 
-if node['hadoop']['hdfs_site'].key?('dfs.domain.socket.path')
+if node['hadoop']['hdfs_site'].key?('dfs.domain.socket.path') # ~FC023
   directory ::File.dirname(node['hadoop']['hdfs_site']['dfs.domain.socket.path']).gsub('file://', '') do
     mode '0750'
     owner 'hdfs'


### PR DESCRIPTION
The documentation for the `duplication` engine on Code Climate leaves a bit to be desired. Anyway, increasing mass_threshold to above that matching the template code used for pretty much every service. This could be abstracted out into a provider at some point, but not today.

As for FC023, it's been removed from foodcritic in the latest versions as people weren't in consensus on this. I prefer disable it inline as I prefer guards where they make sense.