### PR TITLE
Test Chef 13: remove Ruby 2.0, add Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
   - 2.1.4
+  - 2.3.1
 cache: bundler
 sudo: false
 bundler_args: --jobs 7 --without docs integration

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,10 @@ if RUBY_VERSION.to_f < 2.0
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
   gem 'varia_model', '< 0.5.0'
+elsif RUBY_VERSION.to_f > 2.3
+  gem 'chef'
+  gem 'foodcritic'
+  gem 'rubocop'
 else
   gem 'chef', '< 12.5'
   gem 'foodcritic', '~> 6.0'


### PR DESCRIPTION
Update tests to use the latest Chef.