### PR TITLE
Update cookbook headers

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Attribute:: default
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/attributes/hive.rb
+++ b/attributes/hive.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Attribute:: hive
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/attributes/kms.rb
+++ b/attributes/kms.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Attribute:: kms
 #
 # Copyright © 2016 Cask Data, Inc.

--- a/attributes/tez.rb
+++ b/attributes/tez.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Attribute:: tez
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/attributes/zzz_system_tuning.rb
+++ b/attributes/zzz_system_tuning.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Attribute:: zzz_system_tuning
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Library:: helpers
 #
 # Copyright © 2015-2016 Cask Data, Inc.

--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _compression_libs
 #
 # Copyright © 2013-2017 Cask Data, Inc.

--- a/recipes/_hadoop_checkconfig.rb
+++ b/recipes/_hadoop_checkconfig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _hadoop_checkconfig
 #
 # Copyright © 2015 Cask Data, Inc.

--- a/recipes/_hadoop_hdfs_checkconfig.rb
+++ b/recipes/_hadoop_hdfs_checkconfig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _hadoop_hdfs_checkconfig
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/_hadoop_hdfs_ha_checkconfig.rb
+++ b/recipes/_hadoop_hdfs_ha_checkconfig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _hadoop_hdfs_ha_checkconfig
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/_hbase_checkconfig.rb
+++ b/recipes/_hbase_checkconfig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _hbase_checkconfig
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/_hive_checkconfig.rb
+++ b/recipes/_hive_checkconfig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _hive_checkconfig
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/_sql_connectors.rb
+++ b/recipes/_sql_connectors.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _sql_connectors
 #
 # Copyright © 2015-2017 Cask Data, Inc.

--- a/recipes/_storm_checkconfig.rb
+++ b/recipes/_storm_checkconfig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _storm_checkconfig
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/_system_tuning.rb
+++ b/recipes/_system_tuning.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _system_tuning
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/_zookeeper_checkconfig.rb
+++ b/recipes/_zookeeper_checkconfig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: _zookeeper_checkconfig
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/avro.rb
+++ b/recipes/avro.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: avro
 #
 # Copyright © 2013-2014 Cask Data, Inc.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: default
 #
 # Copyright © 2013-2017 Cask Data, Inc.

--- a/recipes/flume.rb
+++ b/recipes/flume.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: flume
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/flume_agent.rb
+++ b/recipes/flume_agent.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: flume_agent
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_datanode
 #
 # Copyright © 2013-2017 Cask Data, Inc.

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_journalnode
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_namenode
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_secondarynamenode
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/hadoop_hdfs_zkfc.rb
+++ b/recipes/hadoop_hdfs_zkfc.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_zkfc
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hadoop_kms.rb
+++ b/recipes/hadoop_kms.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_kms
 #
 # Copyright © 2016 Cask Data, Inc.

--- a/recipes/hadoop_kms_server.rb
+++ b/recipes/hadoop_kms_server.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_kms_server
 #
 # Copyright © 2015-2016 Cask Data, Inc.

--- a/recipes/hadoop_mapreduce_historyserver.rb
+++ b/recipes/hadoop_mapreduce_historyserver.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_mapreduce_historyserver
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_yarn_nodemanager
 #
 # Copyright © 2013-2017 Cask Data, Inc.

--- a/recipes/hadoop_yarn_proxyserver.rb
+++ b/recipes/hadoop_yarn_proxyserver.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_yarn_proxyserver
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hadoop_yarn_resourcemanager
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hbase
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hbase_master
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hbase_regionserver
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hbase_rest.rb
+++ b/recipes/hbase_rest.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hbase_rest
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hbase_thrift.rb
+++ b/recipes/hbase_thrift.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hbase_thrift
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hcatalog.rb
+++ b/recipes/hcatalog.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hcatalog
 #
 # Copyright © 2013-2014 Cask Data, Inc.

--- a/recipes/hive.rb
+++ b/recipes/hive.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hive
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hive_metastore
 #
 # Copyright © 2013-2017 Cask Data, Inc.

--- a/recipes/hive_server.rb
+++ b/recipes/hive_server.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hive_server
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: hive_server
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/oozie.rb
+++ b/recipes/oozie.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: oozie
 #
 # Copyright © 2013-2017 Cask Data, Inc.

--- a/recipes/oozie_client.rb
+++ b/recipes/oozie_client.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: oozie_client
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/parquet.rb
+++ b/recipes/parquet.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: parquet
 #
 # Copyright © 2013-2014 Cask Data, Inc.

--- a/recipes/pig.rb
+++ b/recipes/pig.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: pig
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: repo
 #
 # Copyright © 2013-2016 Cask Data, Inc.

--- a/recipes/spark.rb
+++ b/recipes/spark.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: spark
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: spark_historyserver
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: spark_master
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/spark_worker.rb
+++ b/recipes/spark_worker.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: spark_worker
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/storm.rb
+++ b/recipes/storm.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: storm
 #
 # Copyright © 2015 VAHNA

--- a/recipes/storm_nimbus.rb
+++ b/recipes/storm_nimbus.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: storm_nimbus
 #
 # Copyright © 2015 VAHNA

--- a/recipes/storm_supervisor.rb
+++ b/recipes/storm_supervisor.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: storm_supervisor
 #
 # Copyright © 2015 VAHNA

--- a/recipes/storm_ui.rb
+++ b/recipes/storm_ui.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: storm_ui
 #
 # Copyright © 2015 VAHNA

--- a/recipes/tez.rb
+++ b/recipes/tez.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: tez
 #
 # Copyright © 2013-2015 Cask Data, Inc.

--- a/recipes/zookeeper.rb
+++ b/recipes/zookeeper.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: zookeeper
 #
 # Copyright © 2013-2014 Cask Data, Inc.

--- a/recipes/zookeeper_server.rb
+++ b/recipes/zookeeper_server.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: hadoop
+# Cookbook:: hadoop
 # Recipe:: zookeeper_server
 #
 # Copyright © 2013-2016 Cask Data, Inc.


### PR DESCRIPTION
This replaces `Cookbook Name` with `Cookbook` to match current Chef standards.