### PR TITLE
version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 hadoop CHANGELOG
 ================
 
+v2.11.1 (Jun 19, 2017)
+----------------------
+
+- Add HDP 2.5.5.0 ( Issue: #328 )
+- Update cookbook headers ( Issue: #329 )
+- Support installing Slider ( Issue: #330 )
+- Support Hive2 installation and configuration ( Issue: #331 )
+- Support Spark 2.x (spark2) package ( Issue: #332 )
+- Add HDP 2.6.1 ( Issue: #333 )
+
 v2.11.0 (Apr 18, 2017)
 ----------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
   "recipes": {
 
   },
-  "version": "2.11.0",
+  "version": "2.11.1",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.11.0'
+version          '2.11.1'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
Includes:
- Add HDP 2.5.5.0 ( Issue: #328 )
- Update cookbook headers ( Issue: #329 )
- Support installing Slider ( Issue: #330 )
- Support Hive2 installation and configuration ( Issue: #331 )
- Support Spark 2.x (spark2) package ( Issue: #332 )
- Add HDP 2.6.1 ( Issue: #333 )