### PR TITLE
libsnappy name change on ubuntu 16

### DIFF
--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -24,7 +24,11 @@ pkgs = []
 # Everybody gets snappy
 case node['platform_family']
 when 'debian'
-  pkgs += ['libsnappy1', 'libsnappy-dev']
+  if node['platform_version'] == '16.04'
+      pkgs += ['libsnappy1v5', 'libsnappy-dev']
+  else
+      pkgs += ['libsnappy1', 'libsnappy-dev']
+  end
 when 'rhel', 'amazon'
   pkgs += ['snappy', 'snappy-devel']
 end

--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -24,7 +24,7 @@ pkgs = []
 # Everybody gets snappy
 case node['platform_family']
 when 'debian'
-  pkgs += if node['platform_version'] >= 16
+  pkgs += if node['platform_version'].to_i >= 16
             ['libsnappy1v5', 'libsnappy-dev']
           else
             ['libsnappy1', 'libsnappy-dev']

--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -25,9 +25,9 @@ pkgs = []
 case node['platform_family']
 when 'debian'
   if node['platform_version'] == '16.04'
-      pkgs += ['libsnappy1v5', 'libsnappy-dev']
+    pkgs += ['libsnappy1v5', 'libsnappy-dev']
   else
-      pkgs += ['libsnappy1', 'libsnappy-dev']
+    pkgs += ['libsnappy1', 'libsnappy-dev']
   end
 when 'rhel', 'amazon'
   pkgs += ['snappy', 'snappy-devel']

--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -25,10 +25,10 @@ pkgs = []
 case node['platform_family']
 when 'debian'
   pkgs += if node['platform_version'] >= '16'
-    ['libsnappy1v5', 'libsnappy-dev']
-  else
-    ['libsnappy1', 'libsnappy-dev']
-  end
+            ['libsnappy1v5', 'libsnappy-dev']
+          else
+            ['libsnappy1', 'libsnappy-dev']
+          end
 when 'rhel', 'amazon'
   pkgs += ['snappy', 'snappy-devel']
 end

--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -24,10 +24,10 @@ pkgs = []
 # Everybody gets snappy
 case node['platform_family']
 when 'debian'
-  if node['platform_version'] == '16.04'
-    pkgs += ['libsnappy1v5', 'libsnappy-dev']
+  pkgs += if node['platform_version'] >= '16'
+    ['libsnappy1v5', 'libsnappy-dev']
   else
-    pkgs += ['libsnappy1', 'libsnappy-dev']
+    ['libsnappy1', 'libsnappy-dev']
   end
 when 'rhel', 'amazon'
   pkgs += ['snappy', 'snappy-devel']

--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -24,7 +24,7 @@ pkgs = []
 # Everybody gets snappy
 case node['platform_family']
 when 'debian'
-  pkgs += if node['platform_version'] >= '16'
+  pkgs += if node['platform_version'] >= 16
             ['libsnappy1v5', 'libsnappy-dev']
           else
             ['libsnappy1', 'libsnappy-dev']


### PR DESCRIPTION
The name of libsnappy1 changed in ubuntu 16