### PR TITLE
compatibility fix for sysctl 0.10, which removed default attributes

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -9,6 +9,7 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
   cookbook 'selinux', '< 1.0'
+  cookbook 'sysctl', '< 0.10'
   cookbook 'windows', '< 2.0'
   cookbook 'yum', '< 4.0'
   cookbook 'yum-epel', '< 2.0'
@@ -19,6 +20,7 @@ elsif Chef::VERSION.to_f < 12.5
   cookbook 'mingw', '< 2.0'
   cookbook 'ohai', '< 5.0'
   cookbook 'selinux', '< 1.0'
+  cookbook 'sysctl', '< 0.10'
   cookbook 'windows', '< 3.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.6

--- a/attributes/zzz_system_tuning.rb
+++ b/attributes/zzz_system_tuning.rb
@@ -162,10 +162,9 @@ end
 ###
 
 ports = ports.uniq.sort.to_s.tr(' ', '').tr('[', '').tr(']', '') # De-dupe, Sort, and Stringify
-include_attribute 'sysctl'
 
 # net.ipv4.ip_local_reserved_ports setting (COOK-79)
-if node['sysctl']['params'].key?('net') && node['sysctl']['params']['net'].key?('ipv4') &&
+if node.key?('sysctl') && node['sysctl'].key?('params') && node['sysctl']['params'].key?('net') && node['sysctl']['params']['net'].key?('ipv4') &&
    node['sysctl']['params']['net']['ipv4'].key?('ip_local_reserved_ports')
   orig = node['sysctl']['params']['net']['ipv4']['ip_local_reserved_ports']
   default['sysctl']['params']['net']['ipv4']['ip_local_reserved_ports'] = "#{orig},#{ports}"

--- a/metadata.json
+++ b/metadata.json
@@ -16,9 +16,9 @@
   "dependencies": {
     "yum": ">= 3.0",
     "apt": ">= 2.1.2",
-    "sysctl": "< 0.10.0",
     "dpkg_autostart": ">= 0.0.0",
     "selinux": ">= 0.0.0",
+    "sysctl": ">= 0.0.0",
     "ulimit": ">= 0.0.0"
   },
   "recommendations": {

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,9 +8,8 @@ version          '2.11.4'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'
-depends 'sysctl', '< 0.10.0'
 
-%w(dpkg_autostart selinux ulimit).each do |cb|
+%w(dpkg_autostart selinux sysctl ulimit).each do |cb|
   depends cb
 end
 


### PR DESCRIPTION
sysctl 0.10 is released, which removed the default attributes file.
- [x] removes the ``include_attribute`` which now throws exception, and shouldn't have been necessary before since we declare a dependency on sysctl
- [x] adds a couple more nil checks when probing the sysctl attributes