### PR TITLE
Version bump for release 2.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 hadoop CHANGELOG
 ================
 
+v2.11.4 (Aug 7, 2017)
+---------------------
+
+- Constrain sysctl due to its Chef version dependency ( Issues: #341 )
+
 v2.11.3 (Jul 28, 2017)
 ----------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
   "recipes": {
 
   },
-  "version": "2.11.3",
+  "version": "2.11.4",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.11.3'
+version          '2.11.4'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
Includes:
- Constrain sysctl due to its Chef version dependency ( Issues: #341 )