### PR TITLE
Version bump for 2.11.5 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@
 #
 
 language: ruby
+dist: precise
 rvm:
   - 1.9.3
   - 2.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 hadoop CHANGELOG
 ================
 
+v2.11.5 (Aug 7, 2017)
+---------------------
+
+- Support sysctl cookbook 0.10.0 on Chef 12.5+ ( Issues: #340 )
+
 v2.11.4 (Aug 7, 2017)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
   "recipes": {
 
   },
-  "version": "2.11.4",
+  "version": "2.11.5",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.11.4'
+version          '2.11.5'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
Includes:

- Support sysctl cookbook 0.10.0 on Chef 12.5+ ( Issues: #340 )