### PR TITLE
Fix libsnappy-dev installation on Ubuntu 16.04+

### DIFF
--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -29,6 +29,7 @@ when 'debian'
           else
             ['libsnappy1', 'libsnappy-dev']
           end
+  pkgs += ['libsnappy1'] if node['hadoop']['distribution'] == 'hdp'
 when 'rhel', 'amazon'
   pkgs += ['snappy', 'snappy-devel']
 end


### PR DESCRIPTION
Update the package list for Snappy on Ubuntu 16.04+ to actually
install correctly. This was blocking installation on Ubuntu 16 for
anyone starting from scratch.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>