### PR TITLE
use snappy1 from hdp-utils when hdp on ubuntu16

### DIFF
--- a/recipes/_compression_libs.rb
+++ b/recipes/_compression_libs.rb
@@ -24,7 +24,8 @@ pkgs = []
 # Everybody gets snappy
 case node['platform_family']
 when 'debian'
-  pkgs += if node['platform_version'].to_i >= 16
+  # HDP-UTILS repo provides its own libsnappy1, which conflicts with Ubuntu's libsnappy1v5
+  pkgs += if node['platform_version'].to_i >= 16 && node['hadoop']['distribution'] != 'hdp'
             ['libsnappy1v5', 'libsnappy-dev']
           else
             ['libsnappy1', 'libsnappy-dev']


### PR DESCRIPTION
fix ``libsnappy-dev`` installation on ubuntu16.  HDP-Utils provides ``libsnappy1``, which conflicts with ubuntu's ``libsnappy1v5``.

(or maybe we just specify only ``libsnappy-dev`` and let apt sort it out).