### PR TITLE
configure only hdp update or GA repos, and fix centos7 support

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -87,7 +87,7 @@ when 'hdp'
   case node['platform_family']
   when 'rhel', 'amazon'
     yum_base_url = 'http://public-repo-1.hortonworks.com/HDP'
-    os = if major_platform_version == 5 || hdp_version.to_f >= 2.3
+    os = if major_platform_version == 5 || hdp_update_version.to_f >= 2.3
            "centos#{major_platform_version}"
          else
            'centos6'
@@ -96,22 +96,17 @@ when 'hdp'
     yum_repo_url = node['hadoop']['yum_repo_url'] ? node['hadoop']['yum_repo_url'] : "#{yum_base_url}/#{os}/2.x/GA/#{hdp_version}"
     yum_repo_key_url = node['hadoop']['yum_repo_key_url'] ? node['hadoop']['yum_repo_key_url'] : "#{yum_base_url}/#{os}/#{key}/#{key}-Jenkins"
 
-    yum_repository 'hdp' do
-      name 'HDP-2.x'
-      description 'Hortonworks Data Platform Version - HDP-2.x'
-      url yum_repo_url
-      gpgkey yum_repo_key_url
-      action :add
-    end
     if hdp_update_version.nil?
-      yum_repository 'hdp-updates' do
-        name 'Updates-HDP-2.x'
-        description 'Updates for Hortonworks Data Platform Version - HDP-2.x'
-        url "#{yum_base_url}/#{os}/2.x/updates"
+      # We are on one of the GA versions; configure the GA repo
+      yum_repository 'hdp' do
+        name 'HDP-2.x'
+        description 'Hortonworks Data Platform Version - HDP-2.x'
+        url yum_repo_url
         gpgkey yum_repo_key_url
         action :add
       end
     else
+      # We are on an update version; configure the update repo only
       yum_repository 'hdp-updates' do
         name 'Updates-HDP-2.x'
         description 'Updates for Hortonworks Data Platform Version - HDP-2.x'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -8,7 +8,22 @@ describe 'hadoop::repo' do
       end.converge(described_recipe)
     end
 
-    %w(HDP-2.x Updates-HDP-2.x HDP-UTILS-1.1.0.21).each do |repo|
+    %w(Updates-HDP-2.x HDP-UTILS-1.1.0.21).each do |repo|
+      it "add #{repo} yum_repository" do
+        expect(chef_run).to add_yum_repository(repo)
+      end
+    end
+  end
+
+  context 'using HDP GA release' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+        node.override['hadoop']['distribution_version'] = '2.2.0.0'
+      end.converge(described_recipe)
+    end
+
+    %w(HDP-2.x HDP-UTILS-1.1.0.21).each do |repo|
       it "add #{repo} yum_repository" do
         expect(chef_run).to add_yum_repository(repo)
       end


### PR DESCRIPTION
- [x] Per HDP docs from 2.0 - 2.6, configure either the ``GA`` repo, or an ``update`` repo, not both.  The last GA repo was [2.2.0.0](https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.2.0/bk_installing_manually_book/content/config-remote-repositories.html).
   - [x] updated tests accordingly
- [x] fix centOS7 support, which was incorrectly using the "GA" version instead of the "update" version to determine if supported

I think the whole repo recipe needs refactoring, but tried to minimize changes for now.