### PR TITLE
Version bump for 2.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 hadoop CHANGELOG
 ================
 
+v2.12.0 (Sep 12, 2017)
+----------------------
+
+- Remove redundant HDP version attributes ( Issue: #344 )
+- Update HDP-UTILS repo to 1.1.0.21 ( Issues: #346 [COOK-127](https://issues.cask.co/browse/COOK-127) )
+- Use libsnappy1 from hdp-utils on Ubuntu 16 ( Issue: #347 )
+- Add Support for HDP 2.6.2.0 and HDP 2.5.6.0 ( Issue: #348 )
+- Fix CentOS7 support for HDP, configure only update or GA repo ( Issues: #349 [COOK-129](https://issues.cask.co/browse/COOK-129) )
+- Drop support for RHEL 5 and derivatives ( Issues: #351 [COOK-130](https://issues.cask.co/browse/COOK-130) )
+
 v2.11.5 (Aug 7, 2017)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
   "recipes": {
 
   },
-  "version": "2.11.5",
+  "version": "2.12.0",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.11.5'
+version          '2.12.0'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
I think #349  warrants the minor version bump, as the hdp repo footprint is changing.

Includes:

- Remove redundant HDP version attributes ( Issue: #344 )
- Update HDP-UTILS repo to 1.1.0.21 ( Issues: #346 [COOK-127](https://issues.cask.co/browse/COOK-127) )
- Use libsnappy1 from hdp-utils on Ubuntu 16 ( Issue: #347 )
- Add Support for HDP 2.6.2.0 and HDP 2.5.6.0 ( Issue: #348 )
- Fix CentOS7 support for HDP, configure only update or GA repo ( Issues: #349 [COOK-129](https://issues.cask.co/browse/COOK-129) )
