### PR TITLE
COOK-130 Drop support for RHEL 5 and derivatives

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,11 +6,11 @@
   "maintainer_email": "ops@cask.co",
   "license": "Apache-2.0",
   "platforms": {
+    "centos": ">= 6.0",
+    "redhat": ">= 6.0",
+    "scientific": ">= 6.0",
     "amazon": ">= 0.0.0",
-    "centos": ">= 0.0.0",
     "debian": ">= 0.0.0",
-    "redhat": ">= 0.0.0",
-    "scientific": ">= 0.0.0",
     "ubuntu": ">= 0.0.0"
   },
   "dependencies": {
@@ -21,25 +21,10 @@
     "sysctl": ">= 0.0.0",
     "ulimit": ">= 0.0.0"
   },
-  "recommendations": {
-
-  },
-  "suggestions": {
-
-  },
-  "conflicting": {
-
-  },
   "providing": {
 
   },
-  "replacing": {
-
-  },
   "attributes": {
-
-  },
-  "groupings": {
 
   },
   "recipes": {

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,12 +13,18 @@ depends 'apt', '>= 2.1.2'
   depends cb
 end
 
+# RHEL-like distributions
 %w(
-  amazon
   centos
-  debian
   redhat
   scientific
+).each do |os|
+  supports os, '>= 6.0'
+end
+
+%w(
+  amazon
+  debian
   ubuntu
 ).each do |os|
   supports os

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: repo
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ when 'hdp'
   case node['platform_family']
   when 'rhel', 'amazon'
     yum_base_url = 'http://public-repo-1.hortonworks.com/HDP'
-    os = if major_platform_version == 5 || hdp_update_version.to_f >= 2.3
+    os = if hdp_update_version.to_f >= 2.3
            "centos#{major_platform_version}"
          else
            'centos6'


### PR DESCRIPTION
Redhat stopped production support on RHEL 5 in March 2017. Let's
remove it from the cookbook.

https://access.redhat.com/support/policy/updates/errata

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>