### PR TITLE
add capability to skip system_tuning recipe

### DIFF
--- a/attributes/zzz_system_tuning.rb
+++ b/attributes/zzz_system_tuning.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Attribute:: zzz_system_tuning
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# Set this to false to disable running the _system_tuning recipe. This may be desirable when running in a container.
+default['hadoop']['system_tuning_enabled'] = true
 
 # This attributes file sets up the port reservations for sysctl for COOK-79. Since these values must be compiled into
 # a single value, everything is done in this one file, and is done at Chef compile time, versus in a recipe. This is

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hadoop-hdfs-datanode'
 
 dfs_data_dirs =

--- a/recipes/hadoop_hdfs_journalnode.rb
+++ b/recipes/hadoop_hdfs_journalnode.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_journalnode
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hadoop-hdfs-journalnode'
 
 dfs_jn_edits_dirs =

--- a/recipes/hadoop_hdfs_namenode.rb
+++ b/recipes/hadoop_hdfs_namenode.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_namenode
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hadoop-hdfs-namenode'
 
 dfs_name_dirs =

--- a/recipes/hadoop_hdfs_secondarynamenode.rb
+++ b/recipes/hadoop_hdfs_secondarynamenode.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hadoop_hdfs_secondarynamenode
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::default'
 include_recipe 'hadoop::_hadoop_hdfs_checkconfig'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hadoop-hdfs-secondarynamenode'
 
 fs_checkpoint_dirs =

--- a/recipes/hadoop_yarn_nodemanager.rb
+++ b/recipes/hadoop_yarn_nodemanager.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hadoop-yarn-nodemanager'
 
 # Ensure permissions for secure Hadoop... this *should* be no-op

--- a/recipes/hadoop_yarn_resourcemanager.rb
+++ b/recipes/hadoop_yarn_resourcemanager.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hadoop_yarn_resourcemanager
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::default'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hadoop-yarn-resourcemanager'
 
 # TODO: check for these and set them up

--- a/recipes/hbase_master.rb
+++ b/recipes/hbase_master.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hbase_master
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::hbase'
 include_recipe 'hadoop::_hbase_checkconfig'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hbase-master'
 
 # HBase can use a local directory or an HDFS directory for its rootdir...

--- a/recipes/hbase_regionserver.rb
+++ b/recipes/hbase_regionserver.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hbase_regionserver
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::hbase'
 include_recipe 'hadoop::_hbase_checkconfig'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hbase-regionserver'
 
 hbase_log_dir =

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::hive'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hive-metastore'
 
 hive_sql =

--- a/recipes/hive_server.rb
+++ b/recipes/hive_server.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hive_server
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::hive'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'hive-server'
 
 hive_log_dir =

--- a/recipes/hive_server2.rb
+++ b/recipes/hive_server2.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: hive_server
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 include_recipe 'hadoop::hive'
 include_recipe 'hadoop::_hive_checkconfig'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 include_recipe 'hadoop::zookeeper'
 pkg = 'hive-server2'
 

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: spark_master
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::spark'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'spark-master'
 
 spark_log_dir =

--- a/recipes/spark_worker.rb
+++ b/recipes/spark_worker.rb
@@ -2,7 +2,7 @@
 # Cookbook:: hadoop
 # Recipe:: spark_worker
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'hadoop::spark'
-include_recipe 'hadoop::_system_tuning'
+include_recipe 'hadoop::_system_tuning' if node['hadoop']['system_tuning_enabled']
 pkg = 'spark-worker'
 
 worker_dir =


### PR DESCRIPTION
This adds an attribute to allow one to disable the ``_system_tuning.rb`` recipe.  The primary reason for this would be running this cookbook in containers.  Below is what currently happens when running in Docker (non-privileged).

```
[2017-09-20T05:06:40+00:00] ERROR: execute[sysctl[vm.swappiness]] (/chef/cookbooks/sysctl/providers/param.rb line 21) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '255'
---- Begin output of sysctl -w "vm.swappiness=0" ----
STDOUT: 
STDERR: sysctl: setting key "vm.swappiness": Read-only file system
---- End output of sysctl -w "vm.swappiness=0" ----
Ran sysctl -w "vm.swappiness=0" returned 255
[2017-09-20T05:06:40+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```