### PR TITLE
Version bump for 2.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 hadoop CHANGELOG
 ================
 
+v2.13.0 (Dec 5, 2017)
+---------------------
+
+- Update HDP GPG key location per docs (Issue: #352)
+- Add capability to skip system_tuning recipe (Issue: #353)
+- Update testing framework to modern Chef standards (Issue: #354)
+- Add support for HDP 2.6.3 (Issue: #355)
+
 v2.12.0 (Sep 12, 2017)
 ----------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
   "recipes": {
 
   },
-  "version": "2.12.0",
+  "version": "2.13.0",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.12.0'
+version          '2.13.0'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
#354 warrants the minor version bump.

Includes:
- Update HDP GPG key location per docs (Issue: #352)
- Add capability to skip system_tuning recipe (Issue: #353)
- Update testing framework to modern Chef standards (Issue: #354)
- Add support for HDP 2.6.3 (Issue: #355)
