### PR TITLE
add support for hdp 2.6.4.0

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -72,6 +72,8 @@ module Hadoop
         '2.6.2.0-205'
       when '2.6.3.0'
         '2.6.3.0-235'
+      when '2.6.4.0'
+        '2.6.4.0-91'
       else
         node['hadoop']['distribution_version']
       end

--- a/recipes/hadoop_hdfs_datanode.rb
+++ b/recipes/hadoop_hdfs_datanode.rb
@@ -26,7 +26,7 @@ dfs_data_dirs =
   hadoop_config('hadoop', 'hdfs_site', 'dfs.datanode.data.dir', 'dfs.data.dir', 'file:///tmp/hadoop-hdfs/dfs/data')
 
 dfs_data_dir_perm =
-  hadoop_config('hadoop', 'hdfs_site', 'dfs.datanode.data.dir.perm', 'dfs.data.dir.perm', '0700')
+  hadoop_config('hadoop', 'hdfs_site', 'dfs.datanode.data.dir.perm', 'dfs.data.dir.perm', '700')
 
 node.default['hadoop']['hdfs_site']['dfs.datanode.data.dir'] = dfs_data_dirs
 node.default['hadoop']['hdfs_site']['dfs.datanode.data.dir.perm'] = dfs_data_dir_perm

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -50,7 +50,7 @@ when 'hdp'
        '2.3.0.0', '2.3.2.0', '2.3.4.0', '2.3.4.7', '2.3.6.0',
        '2.4.0.0', '2.4.2.0', '2.4.3.0',
        '2.5.0.0', '2.5.3.0', '2.5.5.0', '2.5.6.0',
-       '2.6.0.3', '2.6.1.0', '2.6.2.0', '2.6.3.0'
+       '2.6.0.3', '2.6.1.0', '2.6.2.0', '2.6.3.0', '2.6.4.0'
     hdp_version = '2.2.0.0'
     hdp_update_version = node['hadoop']['distribution_version']
   when '2.2'
@@ -75,7 +75,7 @@ when 'hdp'
     node.override['hadoop']['distribution_version'] = hdp_update_version
   when '2.6', '2'
     hdp_version = '2.2.0.0'
-    hdp_update_version = '2.6.3.0'
+    hdp_update_version = '2.6.4.0'
     Chef::Log.warn("Short versions for node['hadoop']['distribution_version'] are deprecated! Please use full version!")
     node.override['hadoop']['distribution_version'] = hdp_update_version
   else
@@ -152,7 +152,7 @@ when 'hdp'
            '2.3.0.0', '2.3.2.0', '2.3.4.0', '2.3.4.7', '2.3.6.0',
            '2.4.0.0', '2.4.2.0', '2.4.3.0',
            '2.5.0.0', '2.5.3.0', '2.5.5.0', '2.5.6.0',
-           '2.6.0.3', '2.6.1.0', '2.6.2.0', '2.6.3.0'
+           '2.6.0.3', '2.6.1.0', '2.6.2.0', '2.6.3.0', '2.6.4.0'
         "2.x/updates/#{hdp_update_version}"
       else
         hdp_update_version


### PR DESCRIPTION
add HDP 2.6.4.0 support

```
$ curl -s http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.4.0/build.id | grep BUILD_NUMBER
BUILD_NUMBER: 91
```