### PR TITLE
Version bump for 2.14.0 release

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -62,4 +62,4 @@ suites:
          'hive.support.concurrency': true
          'hive.zookeeper.quorum': 'localhost'
       java:
-        jdk_version: 7
+        jdk_version: '7'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,4 +49,4 @@ suites:
          'hive.support.concurrency': true
          'hive.zookeeper.quorum': 'localhost'
       java:
-        jdk_version: 7
+        jdk_version: '7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 hadoop CHANGELOG
 ================
 
+v2.14.0 (May 4, 2018)
+---------------------
+- add TESTING.md ( Issue: #356 )
+- add support for HDP 2.6.4.0 ( Issues: #358 #359 )
+- add helper to fetch HDP build number from public repository ( Issues: #360 )
+
 v2.13.0 (Dec 5, 2017)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
   "recipes": {
 
   },
-  "version": "2.13.0",
+  "version": "2.14.0",
   "source_url": "https://github.com/caskdata/hadoop_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10600",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Flume, Oozie, Pig, Spark, Storm, Tez, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.13.0'
+version          '2.14.0'
 
 depends 'yum', '>= 3.0'
 depends 'apt', '>= 2.1.2'


### PR DESCRIPTION
includes:
- add TESTING.md ( Issue: #356 )
- add support for HDP 2.6.4.0 ( Issues: #358 #359 )
- add helper to fetch HDP build number from public repository ( Issues: #360 )

Although there should be no change in default behavior, I thought #360 is a big enough change to warrant the minor version bump.  We can say 2.14 potentially supports future HDP releases where 2.13 will not